### PR TITLE
Add KB question editor

### DIFF
--- a/src/commands/modules/kb.js
+++ b/src/commands/modules/kb.js
@@ -6,8 +6,6 @@ const FIND_QUESTION_LEN = 90;
 const FIELD_VALUE_LIMIT = 1000;
 const QUESTION_MODAL_INPUT_ID = 'kb_questions_bulk_text';
 const QUESTIONS_EDIT_ID = 'kb_questions_edit';
-const QUESTIONS_REFRESH_ID = 'kb_questions_refresh';
-const QUESTIONS_CLOSE_ID = 'kb_questions_close';
 
 module.exports = new Command({
     alias: ['kb'],
@@ -339,20 +337,6 @@ async function showQuestions(KB) {
                 case QUESTIONS_EDIT_ID:
                     await interaction.createModal(getQuestionsModal(editor, message.id));
                     return;
-                case QUESTIONS_REFRESH_ID:
-                    editor = await KB.getTagQuestionEditor(editor.tagId);
-                    if (!editor) {
-                        await interaction.editParent({ content: '🚫 **|** That tag no longer exists.', components: [] });
-                        collector.stop('missing');
-                        return;
-                    }
-                    content = renderQuestionEditor(this, editor, 'Refreshed.');
-                    await interaction.editParent(content);
-                    return;
-                case QUESTIONS_CLOSE_ID:
-                    await interaction.acknowledge();
-                    collector.stop('closed');
-                    return;
             }
         } catch (err) {
             console.error(`[KB] questions editor failed for '${editor?.tagId || tagId}':`, err);
@@ -398,8 +382,6 @@ function renderQuestionEditor(command, editor, notice = '') {
                 type: 1,
                 components: [
                     { type: 2, custom_id: QUESTIONS_EDIT_ID, style: 1, label: 'Edit Questions' },
-                    { type: 2, custom_id: QUESTIONS_REFRESH_ID, style: 2, label: 'Refresh' },
-                    { type: 2, custom_id: QUESTIONS_CLOSE_ID, style: 4, label: 'Close' },
                 ],
             },
         ],
@@ -421,7 +403,7 @@ function getQuestionsModal(editor, modalId) {
                         style: 2,
                         max_length: 4000,
                         required: false,
-                        value: editor.rawText || editor.questions.map((question) => question.text).join('\n'),
+                        value: editor.questions.map((question) => question.text).join('\n'),
                         placeholder: 'How do gems work?\nWhen do gems expire?',
                     },
                 ],

--- a/src/commands/modules/kb.js
+++ b/src/commands/modules/kb.js
@@ -328,7 +328,12 @@ async function showQuestions(KB) {
                 acknowledged = true;
                 const result = await KB.updateTagQuestions(editor.tagId, rawText);
                 if (!result) {
-                    await message.edit({ content: '🚫 **|** That tag no longer exists.', components: [] });
+                    content = { content: '🚫 **|** That tag no longer exists.', components: [] };
+                    await message.edit(content);
+                    if (answerMessage) {
+                        await answerMessage.delete().catch(() => {});
+                        answerMessage = null;
+                    }
                     collector.stop('missing');
                     return;
                 }

--- a/src/commands/modules/kb.js
+++ b/src/commands/modules/kb.js
@@ -4,6 +4,10 @@ const { ephemeralInteractionResponse } = require('../../utils/sender');
 const FIND_PREVIEW_LEN = 180;
 const FIND_QUESTION_LEN = 90;
 const FIELD_VALUE_LIMIT = 1000;
+const EMBED_TOTAL_LIMIT = 6000;
+const EMBED_DESCRIPTION_LIMIT = 4096;
+const EMBED_FIELD_VALUE_LIMIT = 1024;
+const ANSWER_CHUNK_LIMIT = 1000;
 const QUESTION_MODAL_INPUT_ID = 'kb_questions_bulk_text';
 const QUESTIONS_EDIT_ID = 'kb_questions_edit';
 
@@ -306,8 +310,10 @@ async function showQuestions(KB) {
         return;
     }
 
-    let content = renderQuestionEditor(this, editor);
+    let rendered = renderQuestionEditorMessages(this, editor);
+    let content = rendered.content;
     const message = await this.send(content);
+    let answerMessage = rendered.answerContent ? await this.send(rendered.answerContent) : null;
     const collectorModule = this.bot.modules['interactioncollector'];
     if (!collectorModule?.create) return;
 
@@ -327,8 +333,16 @@ async function showQuestions(KB) {
                     return;
                 }
                 editor = result.editor;
-                content = renderQuestionEditor(this, editor, summarizeSyncResult('Saved questions', result));
+                rendered = renderQuestionEditorMessages(this, editor, summarizeSyncResult('Saved questions', result));
+                content = rendered.content;
                 await message.edit(content);
+                if (rendered.answerContent) {
+                    if (answerMessage) await answerMessage.edit(rendered.answerContent);
+                    else answerMessage = await this.send(rendered.answerContent);
+                } else if (answerMessage) {
+                    await answerMessage.delete().catch(() => {});
+                    answerMessage = null;
+                }
                 return;
             }
 
@@ -340,7 +354,8 @@ async function showQuestions(KB) {
         } catch (err) {
             console.error(`[KB] questions editor failed for '${editor?.tagId || tagId}':`, err);
             if (acknowledged) {
-                content = renderQuestionEditor(this, editor, `🚫 ${err.message}`);
+                rendered = renderQuestionEditorMessages(this, editor, `🚫 ${err.message}`);
+                content = rendered.content;
                 await message.edit(content).catch(() => {});
             } else {
                 await interaction.createMessage(ephemeralInteractionResponse(`🚫 **|** ${err.message}`)).catch(() => {});
@@ -354,7 +369,7 @@ async function showQuestions(KB) {
     });
 }
 
-function renderQuestionEditor(command, editor, notice = '') {
+function renderQuestionEditorMessages(command, editor, notice = '') {
     const renderedQuestions = editor.questions.map((q, i) => `${i + 1}. ${q.text}`).join('\n');
     const questions = editor.questions.length
         ? renderedQuestions.slice(0, 3000)
@@ -369,11 +384,26 @@ function renderQuestionEditor(command, editor, notice = '') {
     if (!editor.cacheCurrent) status.push('**Cache:** metadata will be refreshed on next sync.');
     if (notice) status.push('', notice);
 
+    const answer = String(editor.answer || '').trim() || 'No answer text is stored for this tag.';
+    const combinedDescription = `${status.join('\n')}\n\n${questions}\n\n**Answer:**\n${answer}`;
+    const combinedContent = buildQuestionContent(command, editor, combinedDescription);
+
+    if (canSendSingleEditorEmbed(combinedContent.embed)) {
+        return { content: combinedContent, answerContent: null };
+    }
+
+    return {
+        content: buildQuestionContent(command, editor, `${status.join('\n')}\n\n${questions}`),
+        answerContent: buildAnswerContent(command, editor, answer),
+    };
+}
+
+function buildQuestionContent(command, editor, description) {
     return {
         embed: {
             title: `KB Retrieval Questions — ${editor.tagId}`,
             color: command.config.embedcolor,
-            description: `${status.join('\n')}\n\n${questions}`,
+            description,
             footer: { text: 'Edit one retrieval question per line. Tag answers still use only tag data.' },
         },
         components: [
@@ -385,6 +415,54 @@ function renderQuestionEditor(command, editor, notice = '') {
             },
         ],
     };
+}
+
+function buildAnswerContent(command, editor, answer) {
+    const chunks = chunkAnswer(answer, EMBED_TOTAL_LIMIT - `KB Tag Answer — ${editor.tagId}`.length);
+    return {
+        embed: {
+            title: `KB Tag Answer — ${editor.tagId}`,
+            color: command.config.embedcolor,
+            fields: chunks.map((chunk, index) => ({
+                name: chunks.length === 1 ? 'Answer' : `Answer ${index + 1}/${chunks.length}`,
+                value: chunk,
+            })),
+        },
+    };
+}
+
+function canSendSingleEditorEmbed(embed) {
+    return embed.description.length <= EMBED_DESCRIPTION_LIMIT && getEmbedTextLength(embed) <= EMBED_TOTAL_LIMIT;
+}
+
+function getEmbedTextLength(embed) {
+    const fields = embed.fields || [];
+    return (
+        String(embed.title || '').length +
+        String(embed.description || '').length +
+        String(embed.footer?.text || '').length +
+        fields.reduce((total, field) => total + String(field.name || '').length + String(field.value || '').length, 0)
+    );
+}
+
+function chunkAnswer(answer, remainingLimit) {
+    const chunks = [];
+    let remaining = String(answer || '');
+    let available = Math.max(EMBED_FIELD_VALUE_LIMIT, remainingLimit - 50);
+
+    while (remaining.length && chunks.length < 6 && available > 0) {
+        const maxChunk = Math.min(ANSWER_CHUNK_LIMIT, available);
+        chunks.push(remaining.slice(0, maxChunk));
+        remaining = remaining.slice(maxChunk);
+        available -= maxChunk + 16;
+    }
+
+    if (remaining.length && chunks.length) {
+        const last = chunks[chunks.length - 1];
+        chunks[chunks.length - 1] = `${last.slice(0, Math.max(0, last.length - 24))}…\n(truncated)`;
+    }
+
+    return chunks.length ? chunks : ['No answer text is stored for this tag.'];
 }
 
 function getQuestionsModal(editor, modalId) {

--- a/src/commands/modules/kb.js
+++ b/src/commands/modules/kb.js
@@ -1,8 +1,13 @@
 const Command = require('../Command.js');
+const { ephemeralInteractionResponse } = require('../../utils/sender');
 
 const FIND_PREVIEW_LEN = 180;
 const FIND_QUESTION_LEN = 90;
 const FIELD_VALUE_LIMIT = 1000;
+const QUESTION_MODAL_INPUT_ID = 'kb_questions_bulk_text';
+const QUESTIONS_EDIT_ID = 'kb_questions_edit';
+const QUESTIONS_REFRESH_ID = 'kb_questions_refresh';
+const QUESTIONS_CLOSE_ID = 'kb_questions_close';
 
 module.exports = new Command({
     alias: ['kb'],
@@ -19,7 +24,7 @@ module.exports = new Command({
         '- `snail kb reindex dry`\n  - Show what a reindex would do without making changes\n' +
         '- `snail kb reset confirm`\n  - Destructively recreate the Qdrant collection, then sync Mongo tags. Remote resets require backup through `ssh hub.corg.network` first.\n' +
         '- `snail kb find {query}`\n  - Search matching tags for manager/debug review\n' +
-        '- `snail kb questions {tag}`\n  - Show generated retrieval questions cached in Mongo for a tag\n' +
+        '- `snail kb questions {tag}`\n  - Show/edit retrieval questions cached in Mongo for a tag\n' +
         '- `snail kb exclude {tag...}`\n  - Exclude one or more tags from KB retrieval and delete their Qdrant points\n' +
         '- `snail kb include {tag...}`\n  - Include one or more tags in KB retrieval and sync their Qdrant points\n' +
         '- `snail kb excluded`\n  - List tags excluded from KB retrieval\n' +
@@ -137,7 +142,7 @@ function formatSyncProgress(progress) {
 
     if (progress.totalAnswers || progress.totalQuestions) {
         lines.push(
-            ` - point types: ${progress.totalAnswers} tag data + ${progress.totalQuestions} generated questions`
+            ` - point types: ${progress.totalAnswers} tag data + ${progress.totalQuestions} retrieval questions`
         );
     }
     if (progress.totalEmbeds) lines.push(` - embedded: ${progress.embeddedPoints}/${progress.totalEmbeds}`);
@@ -173,7 +178,7 @@ async function runReindex(KB) {
                 `**Unchanged:** ${summary.unchanged}\n` +
                 `**Tags:** ${summary.totalTags}\n` +
                 `**Points:** ${summary.totalPoints} ` +
-                `(${summary.totalQuestions} generated questions + ${summary.totalAnswers} tag data points)`,
+                `(${summary.totalQuestions} retrieval questions + ${summary.totalAnswers} tag data points)`,
         };
         await status.edit({ content: '', embed });
     } catch (err) {
@@ -211,7 +216,7 @@ async function runReset(KB) {
                 `**Collection:** \`${summary.collection || KB.collection}\`\n` +
                 `**Tags:** ${summary.totalTags}\n` +
                 `**Points:** ${summary.totalPoints} ` +
-                `(${summary.totalQuestions} generated questions + ${summary.totalAnswers} tag data points)\n\n` +
+                `(${summary.totalQuestions} retrieval questions + ${summary.totalAnswers} tag data points)\n\n` +
                 `**Backup reminder:** ${backupReminder}`,
         };
         await status.edit({ content: '', embed });
@@ -262,7 +267,7 @@ async function runFind(KB) {
         const ellipsis = (group.dataPreview || '').length > FIND_PREVIEW_LEN ? '…' : '';
         const value =
             `**Matched kinds:** ${kinds}\n` +
-            `**Generated-question matches:**\n${questions}\n` +
+            `**Retrieval-question matches:**\n${questions}\n` +
             `**Tag data preview:** ${preview}${ellipsis}\n` +
             `**Manage:** \`snail tag edit ${group.tagId} {data}\` or \`snail tag delete ${group.tagId}\``;
         return {
@@ -290,40 +295,165 @@ async function showQuestions(KB) {
         return;
     }
 
-    let cache;
+    let editor;
     try {
-        cache = await KB.getTagQuestionCache(tagId);
+        editor = await KB.getTagQuestionEditor(tagId);
     } catch (err) {
-        console.error('[KB] getTagQuestionCache failed:', err);
+        console.error('[KB] getTagQuestionEditor failed:', err);
         await this.error(`failed to read cached questions: \`${err.message}\``);
         return;
     }
 
-    if (!cache) {
+    if (!editor) {
         await this.error(`I could not find tag \`${tagId}\`.`);
         return;
     }
 
-    const renderedQuestions = cache.questions.map((q, i) => `${i + 1}. ${q.text}`).join('\n');
-    const questions = cache.questions.length
-        ? renderedQuestions.slice(0, 3500)
-        : 'No generated questions are cached for this tag yet. Run `snail kb reindex` to generate them.';
-    const generatedAt = cache.generatedAt
-        ? `<t:${Math.floor(new Date(cache.generatedAt).getTime() / 1000)}:R>`
-        : 'never';
+    let content = renderQuestionEditor(this, editor);
+    const message = await this.send(content);
+    const collectorModule = this.bot.modules['interactioncollector'];
+    if (!collectorModule?.create) return;
 
-    await this.send({
-        embed: {
-            title: `KB Generated Questions — ${cache.tagId}`,
-            color: this.config.embedcolor,
-            description:
-                `**Excluded:** ${cache.excluded ? 'yes' : 'no'}\n` +
-                `**Prompt Version:** \`${cache.promptVersion || 'none'}\`\n` +
-                `**Generated:** ${generatedAt}\n` +
-                `**Question Count:** ${cache.questions.length}\n\n` +
-                questions,
-        },
+    const filter = (user) => this.message.author.id === user.id;
+    const collector = collectorModule.create(message, filter, { idle: 120000 });
+    collector.on('collect', async (data, interaction) => {
+        let acknowledged = false;
+        try {
+            if (data.isModal) {
+                const rawText = getModalInputValue(data, QUESTION_MODAL_INPUT_ID);
+                await interaction.acknowledge();
+                acknowledged = true;
+                const result = await KB.updateTagQuestions(editor.tagId, rawText);
+                if (!result) {
+                    await message.edit({ content: '🚫 **|** That tag no longer exists.', components: [] });
+                    collector.stop('missing');
+                    return;
+                }
+                editor = result.editor;
+                content = renderQuestionEditor(this, editor, summarizeSyncResult('Saved questions', result));
+                await message.edit(content);
+                return;
+            }
+
+            switch (data.custom_id) {
+                case QUESTIONS_EDIT_ID:
+                    await interaction.createModal(getQuestionsModal(editor, message.id));
+                    return;
+                case QUESTIONS_REFRESH_ID:
+                    editor = await KB.getTagQuestionEditor(editor.tagId);
+                    if (!editor) {
+                        await interaction.editParent({ content: '🚫 **|** That tag no longer exists.', components: [] });
+                        collector.stop('missing');
+                        return;
+                    }
+                    content = renderQuestionEditor(this, editor, 'Refreshed.');
+                    await interaction.editParent(content);
+                    return;
+                case QUESTIONS_CLOSE_ID:
+                    await interaction.acknowledge();
+                    collector.stop('closed');
+                    return;
+            }
+        } catch (err) {
+            console.error(`[KB] questions editor failed for '${editor?.tagId || tagId}':`, err);
+            if (acknowledged) {
+                content = renderQuestionEditor(this, editor, `🚫 ${err.message}`);
+                await message.edit(content).catch(() => {});
+            } else {
+                await interaction.createMessage(ephemeralInteractionResponse(`🚫 **|** ${err.message}`)).catch(() => {});
+            }
+        }
     });
+
+    collector.on('end', async () => {
+        disableComponents(content);
+        await message.edit(content).catch(() => {});
+    });
+}
+
+function renderQuestionEditor(command, editor, notice = '') {
+    const renderedQuestions = editor.questions.map((q, i) => `${i + 1}. ${q.text}`).join('\n');
+    const questions = editor.questions.length
+        ? renderedQuestions.slice(0, 3000)
+        : 'No retrieval questions are cached for this tag. Use **Edit Questions** to add retrieval questions, or leave it empty to index only the tag answer.';
+    const generatedAt = editor.generatedAt ? `<t:${Math.floor(new Date(editor.generatedAt).getTime() / 1000)}:R>` : 'never';
+    const status = [
+        `**Excluded:** ${editor.excluded ? 'yes (Qdrant tag points are deleted)' : 'no'}`,
+        `**Prompt Version:** \`${editor.promptVersion || 'none'}\``,
+        `**Generated:** ${generatedAt}`,
+        `**Question Count:** ${editor.questions.length}`,
+    ];
+    if (!editor.cacheCurrent) status.push('**Cache:** metadata will be refreshed on next sync.');
+    if (notice) status.push('', notice);
+
+    return {
+        embed: {
+            title: `KB Retrieval Questions — ${editor.tagId}`,
+            color: command.config.embedcolor,
+            description: `${status.join('\n')}\n\n${questions}`,
+            footer: { text: 'Edit one retrieval question per line. Tag answers still use only tag data.' },
+        },
+        components: [
+            {
+                type: 1,
+                components: [
+                    { type: 2, custom_id: QUESTIONS_EDIT_ID, style: 1, label: 'Edit Questions' },
+                    { type: 2, custom_id: QUESTIONS_REFRESH_ID, style: 2, label: 'Refresh' },
+                    { type: 2, custom_id: QUESTIONS_CLOSE_ID, style: 4, label: 'Close' },
+                ],
+            },
+        ],
+    };
+}
+
+function getQuestionsModal(editor, modalId) {
+    return {
+        title: `Edit KB questions: ${editor.tagId}`.slice(0, 45),
+        custom_id: modalId,
+        components: [
+            {
+                type: 1,
+                components: [
+                    {
+                        type: 4,
+                        custom_id: QUESTION_MODAL_INPUT_ID,
+                        label: 'One retrieval question per line',
+                        style: 2,
+                        max_length: 4000,
+                        required: false,
+                        value: editor.rawText || editor.questions.map((question) => question.text).join('\n'),
+                        placeholder: 'How do gems work?\nWhen do gems expire?',
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+function getModalInputValue(data, customId) {
+    for (const row of data.components || []) {
+        for (const component of row.components || []) {
+            if (component.custom_id === customId) return component.value || '';
+        }
+    }
+    return '';
+}
+
+function summarizeSyncResult(label, result) {
+    if (result.excluded) return `${label}. Tag is excluded, so Qdrant tag points were deleted.`;
+    return (
+        `${label}. Qdrant sync: ` +
+        `+${result.added || 0}, ~${result.vectorUpdated || 0} vectors, ` +
+        `~${result.metaUpdated || 0} payloads, -${result.deleted || 0}.`
+    );
+}
+
+function disableComponents(content) {
+    for (const row of content.components || []) {
+        for (const component of row.components || []) {
+            component.disabled = true;
+        }
+    }
 }
 
 async function setTagExcluded(KB, excluded) {

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -498,13 +498,10 @@ module.exports = class KnowledgeBase extends require('./Module') {
         return {
             tagId: normalizedTagId,
             excluded: isTagKbExcluded(tag),
-            dataHash,
             promptVersion: tag.kb?.promptVersion,
-            generationHash: tag.kb?.generationHash,
             cacheCurrent: isCurrentTagKbCache(tag.kb, dataHash, generationHash),
             generatedAt: tag.kb?.generatedAt,
             questions,
-            rawText: questions.map((question) => question.text).join('\n'),
         };
     }
 
@@ -759,17 +756,12 @@ function isCurrentTagKbCache(kb, dataHash, generationHash) {
         kb?.dataHash === dataHash &&
         kb?.promptVersion === TAG_QUESTION_PROMPT_VERSION &&
         kb?.generationHash === generationHash &&
-        hasValidQuestionCacheEntries(activeQuestionCacheEntries(kb.questions))
+        hasValidQuestionCacheEntries(kb.questions)
     );
 }
 
 function hasInitializedQuestionCache(kb) {
     return Array.isArray(kb?.questions);
-}
-
-function activeQuestionCacheEntries(questions) {
-    if (!Array.isArray(questions)) return [];
-    return questions.filter((question) => question?.disabled !== true && question?.enabled !== false);
 }
 
 function hasValidQuestionCacheEntries(questions) {
@@ -879,7 +871,7 @@ function toQuestionCacheEntries(questions) {
 function normalizeExistingQuestions(questions) {
     const out = [];
     const seen = new Set();
-    for (const question of activeQuestionCacheEntries(questions)) {
+    for (const question of questions || []) {
         if (typeof question?.text !== 'string' || typeof question?.hash !== 'string') continue;
         const text = question.text.replace(/\s+/g, ' ').trim();
         if (!text || question.hash !== sha1(text)) continue;

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -762,7 +762,13 @@ function isCurrentTagKbCache(kb, dataHash, generationHash) {
 }
 
 function hasInitializedQuestionCache(kb) {
-    return Array.isArray(kb?.questions);
+    return (
+        Array.isArray(kb?.questions) &&
+        (typeof kb?.dataHash === 'string' ||
+            typeof kb?.promptVersion === 'string' ||
+            typeof kb?.generationHash === 'string' ||
+            Boolean(kb?.generatedAt))
+    );
 }
 
 function hasValidQuestionCacheEntries(questions) {

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -497,6 +497,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
 
         return {
             tagId: normalizedTagId,
+            answer: String(tag.data || ''),
             excluded: isTagKbExcluded(tag),
             promptVersion: tag.kb?.promptVersion,
             cacheCurrent: isCurrentTagKbCache(tag.kb, dataHash, generationHash),

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -435,6 +435,24 @@ module.exports = class KnowledgeBase extends require('./Module') {
             return tag.kb;
         }
 
+        if (hasInitializedQuestionCache(tag.kb)) {
+            const kb = buildTagKbCache(tag, normalizeExistingQuestions(tag.kb.questions), dataHash, generationHash, {
+                generatedAt: tag.kb?.generatedAt,
+            });
+            await this.persistTagKb(tag, kb);
+            return tag.kb;
+        }
+
+        if (!this.openrouterApiKey) throw new Error('Missing OPENROUTER_API_KEY');
+
+        const questions = await this.generateTagQuestions(tag);
+        const kb = buildTagKbCache(tag, questions, dataHash, generationHash);
+
+        await this.persistTagKb(tag, kb);
+        return tag.kb;
+    }
+
+    async generateTagQuestions(tag) {
         if (!this.openrouterApiKey) throw new Error('Missing OPENROUTER_API_KEY');
 
         const { content } = await chat({
@@ -455,19 +473,10 @@ module.exports = class KnowledgeBase extends require('./Module') {
             throw err;
         }
 
-        const questions = normalizeGeneratedQuestions(generatedQuestions).map((text) => ({
-            text,
-            hash: sha1(text),
-        }));
+        return toQuestionCacheEntries(normalizeGeneratedQuestions(generatedQuestions));
+    }
 
-        const kb = {
-            dataHash,
-            promptVersion: TAG_QUESTION_PROMPT_VERSION,
-            generationHash,
-            questions,
-            generatedAt: new Date(),
-        };
-
+    async persistTagKb(tag, kb) {
         tag.kb = kb;
         if (typeof tag.set === 'function') tag.set('kb', kb);
         if (typeof tag.save === 'function') {
@@ -475,7 +484,56 @@ module.exports = class KnowledgeBase extends require('./Module') {
         } else {
             await this.Tag.updateOne({ _id: String(tag._id) }, { $set: { kb } });
         }
-        return tag.kb;
+    }
+
+    async getTagQuestionEditor(tagId) {
+        const normalizedTagId = String(tagId);
+        const tag = await leanQuery(this.Tag.findById(normalizedTagId));
+        if (!tag) return null;
+
+        const dataHash = tagDataHash(tag.data);
+        const generationHash = tagQuestionGenerationHash(tag, dataHash);
+        const questions = hasInitializedQuestionCache(tag.kb) ? normalizeExistingQuestions(tag.kb.questions) : [];
+
+        return {
+            tagId: normalizedTagId,
+            excluded: isTagKbExcluded(tag),
+            dataHash,
+            promptVersion: tag.kb?.promptVersion,
+            generationHash: tag.kb?.generationHash,
+            cacheCurrent: isCurrentTagKbCache(tag.kb, dataHash, generationHash),
+            generatedAt: tag.kb?.generatedAt,
+            questions,
+            rawText: questions.map((question) => question.text).join('\n'),
+        };
+    }
+
+    async updateTagQuestions(tagId, rawText) {
+        return this.enqueueSyncOperation(() => this.updateTagQuestionsUnlocked(tagId, rawText));
+    }
+
+    async updateTagQuestionsUnlocked(tagId, rawText) {
+        const normalizedTagId = String(tagId);
+        const tag = await this.Tag.findById(normalizedTagId);
+        if (!tag) return null;
+
+        const dataHash = tagDataHash(tag.data);
+        const generationHash = tagQuestionGenerationHash(tag, dataHash);
+        const questions = toQuestionCacheEntries(normalizeManualQuestions(rawText));
+        const kb = buildTagKbCache(tag, questions, dataHash, generationHash, {
+            generatedAt: tag.kb?.generatedAt,
+        });
+
+        await this.persistTagKb(tag, kb);
+        const summary = isTagKbExcluded(tag)
+            ? await this.deleteTagByIdUnlocked(normalizedTagId).then(() => ({
+                tagId: normalizedTagId,
+                excluded: true,
+                deleted: true,
+            }))
+            : await this.syncTagByIdUnlocked(normalizedTagId);
+
+        return { ...summary, editor: await this.getTagQuestionEditor(normalizedTagId) };
     }
 
     tagFilter(tagId) {
@@ -566,21 +624,6 @@ module.exports = class KnowledgeBase extends require('./Module') {
     async listKbExcludedTags() {
         const docs = await leanQuery(this.Tag.find({ 'knowledgeBase.excluded': true }));
         return docs.map((tag) => String(tag._id)).sort((a, b) => a.localeCompare(b));
-    }
-
-    async getTagQuestionCache(tagId) {
-        const normalizedTagId = String(tagId);
-        const tag = await leanQuery(this.Tag.findById(normalizedTagId));
-        if (!tag) return null;
-        return {
-            tagId: normalizedTagId,
-            excluded: isTagKbExcluded(tag),
-            dataHash: tag.kb?.dataHash,
-            promptVersion: tag.kb?.promptVersion,
-            generationHash: tag.kb?.generationHash,
-            generatedAt: tag.kb?.generatedAt,
-            questions: Array.isArray(tag.kb?.questions) ? tag.kb.questions : [],
-        };
     }
 
     async resetQdrantAndSync() {
@@ -712,20 +755,46 @@ function tagQuestionGenerationHash(tag, dataHash = tagDataHash(tag.data)) {
 
 function isCurrentTagKbCache(kb, dataHash, generationHash) {
     return (
+        hasInitializedQuestionCache(kb) &&
         kb?.dataHash === dataHash &&
         kb?.promptVersion === TAG_QUESTION_PROMPT_VERSION &&
         kb?.generationHash === generationHash &&
-        hasValidGeneratedQuestionCache(kb.questions)
+        hasValidQuestionCacheEntries(activeQuestionCacheEntries(kb.questions))
     );
 }
 
-function hasValidGeneratedQuestionCache(questions) {
-    if (!Array.isArray(questions) || questions.length < 5 || questions.length > 8) return false;
+function hasInitializedQuestionCache(kb) {
+    return Array.isArray(kb?.questions);
+}
+
+function activeQuestionCacheEntries(questions) {
+    if (!Array.isArray(questions)) return [];
+    return questions.filter((question) => question?.disabled !== true && question?.enabled !== false);
+}
+
+function hasValidQuestionCacheEntries(questions) {
+    if (!Array.isArray(questions) || questions.length > 8) return false;
     return questions.every((question) => {
         if (typeof question?.text !== 'string' || typeof question?.hash !== 'string') return false;
         const text = question.text.replace(/\s+/g, ' ').trim();
         return Boolean(text) && question.text === text && question.hash === sha1(text);
     });
+}
+
+function buildTagKbCache(
+    tag,
+    questions,
+    dataHash = tagDataHash(tag.data),
+    generationHash = tagQuestionGenerationHash(tag, dataHash),
+    options = {}
+) {
+    return {
+        dataHash,
+        promptVersion: TAG_QUESTION_PROMPT_VERSION,
+        generationHash,
+        questions,
+        generatedAt: options.generatedAt || new Date(),
+    };
 }
 
 function buildTagQuestionMessages(tag) {
@@ -788,11 +857,46 @@ function normalizeGeneratedQuestions(questions) {
     return out;
 }
 
+function normalizeManualQuestions(rawText) {
+    const out = [];
+    const seen = new Set();
+    for (const line of String(rawText ?? '').split(/\r?\n/)) {
+        const text = line.replace(/\s+/g, ' ').trim().slice(0, 180);
+        if (!text) continue;
+        const key = text.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push(text);
+        if (out.length > 8) throw new Error('Please keep retrieval questions to 8 lines or fewer.');
+    }
+    return out;
+}
+
+function toQuestionCacheEntries(questions) {
+    return questions.map((text) => ({ text, hash: sha1(text) }));
+}
+
+function normalizeExistingQuestions(questions) {
+    const out = [];
+    const seen = new Set();
+    for (const question of activeQuestionCacheEntries(questions)) {
+        if (typeof question?.text !== 'string' || typeof question?.hash !== 'string') continue;
+        const text = question.text.replace(/\s+/g, ' ').trim();
+        if (!text || question.hash !== sha1(text)) continue;
+        const key = text.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push(text);
+        if (out.length === 8) break;
+    }
+    return toQuestionCacheEntries(out);
+}
+
 function buildDesiredTagPoints(tag, namespace) {
     const tagId = String(tag._id);
     const data = String(tag.data ?? '').trim();
     const dataHash = tag.kb?.dataHash || tagDataHash(data);
-    const questions = Array.isArray(tag.kb?.questions) ? tag.kb.questions : [];
+    const questions = hasInitializedQuestionCache(tag.kb) ? normalizeExistingQuestions(tag.kb.questions) : [];
     const desired = new Map();
 
     const answerPointId = toPointId(namespace, `tag:${tagId}:tag_answer:${dataHash}`);


### PR DESCRIPTION
## Summary
- add `snail kb questions {tag}` as the bulk retrieval-question editor with a single Edit Questions modal
- persist one question per nonblank line to `Tag.kb.questions`, including valid empty lists
- keep retrieval-question normalization, hashing, Mongo persistence, and Qdrant sync/delete in `KnowledgeBase`
- preserve initialized question lists when tag data changes, so `snail tag edit` does not regenerate/replace questions
- ensure removed questions/excluded tags are omitted from Qdrant via per-tag sync/delete

## Verification
- `node -c src/modules/KnowledgeBase.js`
- `node -c src/commands/modules/kb.js`
- `node -c src/commands/util/tag.js`
- `npx eslint --no-ignore src/modules/KnowledgeBase.js src/commands/modules/kb.js src/commands/util/tag.js`
- `git diff --check origin/master...HEAD`
- PDD phase review: APPROVED
- final broad review after merge: APPROVED
- final ponytail review after merge: APPROVED


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive editor to manage retrieval questions for knowledge-base tags.
  * Questions can be edited via a modal and updates are reflected immediately in the command response.
* **Improvements**
  * Updated terminology across help text and UI labels to use “retrieval questions.”
  * Refreshed progress and completion summaries for reindex/reset actions, and improved status/results labeling for knowledge-base queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->