### PR TITLE
Add KB reranker for ask candidates

### DIFF
--- a/config.json
+++ b/config.json
@@ -42,11 +42,13 @@
         "embeddingSize": 4096,
         "queryInstruction": "Given a user question about the OwO Discord bot, retrieve a matching knowledge base entry that answers it.",
         "topK": 6,
+        "rerankCandidateLimit": 50,
         "scoreThreshold": 0.7
     },
     "openrouter": {
         "embeddingModel": "qwen/qwen3-embedding-8b",
         "chatModel": "deepseek/deepseek-v3.2",
+        "rerankModel": "cohere/rerank-4-fast",
         "maxTokens": 500,
         "temperature": 0.2,
         "excludedProviders": ["deepinfra", "novita", "gmicloud", "atlas-cloud", "siliconflow"]

--- a/config.json
+++ b/config.json
@@ -43,7 +43,7 @@
         "queryInstruction": "Given a user question about the OwO Discord bot, retrieve a matching knowledge base entry that answers it.",
         "topK": 6,
         "rerankCandidateLimit": 50,
-        "scoreThreshold": 0.7
+        "scoreThreshold": 0.5
     },
     "openrouter": {
         "embeddingModel": "qwen/qwen3-embedding-8b",

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -278,6 +278,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
         const rawHits = await this.qdrant.search(this.collection, {
             vector,
             limit: this.rerankCandidateLimit,
+            scoreThreshold: this.scoreThreshold,
             ...remainingAskRequestOptions(askStartedAt, ASK_QDRANT_TIMEOUT, ASK_QDRANT_RETRY_ATTEMPTS),
         });
 

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -349,10 +349,12 @@ module.exports = class KnowledgeBase extends require('./Module') {
 
         const rawHits = await this.qdrant.search(this.collection, {
             vector,
-            limit: limit * 5,
+            limit: Math.max(this.rerankCandidateLimit, limit * 5),
+            scoreThreshold: this.scoreThreshold,
         });
 
-        return (await this.materializeTagGroups(groupHitsByTag(rawHits))).slice(0, limit);
+        const groups = await this.materializeTagGroups(groupHitsByTag(rawHits));
+        return (await this.rerankTagGroups(question, groups)).slice(0, limit);
     }
 
     async materializeTagGroups(groups) {

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -23,6 +23,7 @@ const ASK_DEADLINE_MS = 90000;
 const ASK_QDRANT_TIMEOUT = 15000;
 const ASK_QDRANT_RETRY_ATTEMPTS = 2;
 const ASK_RETRY_DELAY_MS = 500;
+const DEFAULT_RERANK_CANDIDATE_LIMIT = 30;
 const ASK_FEEDBACK_IDLE_MS = 30 * 60 * 1000;
 const ASK_FEEDBACK_HELPFUL_ID = 'kb_ask_feedback_helpful';
 const ASK_FEEDBACK_NEEDS_FIX_ID = 'kb_ask_feedback_needs_fix';
@@ -59,6 +60,8 @@ module.exports = class KnowledgeBase extends require('./Module') {
             kbConfig.queryInstruction ||
             'Given a user question about the OwO Discord bot, retrieve a matching knowledge base entry that answers it.';
         this.topK = kbConfig.topK ?? 6;
+        this.rerankCandidateLimit =
+            kbConfig.rerankCandidateLimit ?? Math.max(DEFAULT_RERANK_CANDIDATE_LIMIT, this.topK * 5);
         this.scoreThreshold = kbConfig.scoreThreshold ?? 0.3;
         this.dupeThreshold = kbConfig.dupeThreshold ?? 0.75;
         this.askFeedbackChannel = kbConfig.askFeedbackChannel;
@@ -274,13 +277,13 @@ module.exports = class KnowledgeBase extends require('./Module') {
         assertAskBudget(askStartedAt);
         const rawHits = await this.qdrant.search(this.collection, {
             vector,
-            limit: this.topK * 3,
-            scoreThreshold: this.scoreThreshold,
+            limit: this.rerankCandidateLimit,
             ...remainingAskRequestOptions(askStartedAt, ASK_QDRANT_TIMEOUT, ASK_QDRANT_RETRY_ATTEMPTS),
         });
 
         assertAskBudget(askStartedAt);
-        const groups = (await this.materializeTagGroups(groupHitsByTag(rawHits))).slice(0, this.topK);
+        const candidateGroups = await this.materializeTagGroups(groupHitsByTag(rawHits));
+        const groups = await this.rerankTagGroups(question, candidateGroups);
         const hits = groups.flatMap((group) => group.hits);
 
         if (!groups.length) {
@@ -305,6 +308,21 @@ module.exports = class KnowledgeBase extends require('./Module') {
             sources,
             hits,
         };
+    }
+
+    async rerankTagGroups(question, groups) {
+        if (groups.length <= 1) return groups.slice(0, this.topK);
+
+        try {
+            const documents = groups.map(formatRerankTagDocument);
+            const rankings = await this.openrouter.rerank(question, documents, {
+                topN: Math.min(this.topK, documents.length),
+            });
+            return selectRerankedGroups(groups, rankings, this.topK);
+        } catch (err) {
+            console.error('[KB] rerank failed, falling back to dense order:', err.message);
+            return groups.slice(0, this.topK);
+        }
     }
 
     async debugSearch(question, { limit, includeBelowThreshold = true } = {}) {
@@ -743,6 +761,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
             `- Collection: ${this.collection}\n` +
             `- Embedding Size: ${this.embeddingSize}d\n` +
             `- Top K: ${this.topK}\n` +
+            `- Rerank Candidates: ${this.rerankCandidateLimit}\n` +
             `- Score Threshold: ${this.scoreThreshold}\n` +
             `- Dupe Threshold: ${this.dupeThreshold}\n` +
             `- Last Sync: ${last}`
@@ -1175,12 +1194,39 @@ function previewText(text, max) {
     return normalized.length > max ? `${normalized.slice(0, max - 1)}…` : normalized;
 }
 
+function selectRerankedGroups(groups, rankings, topK) {
+    const selected = [];
+    const selectedIndexes = new Set();
+
+    for (const ranking of rankings) {
+        const group = groups[ranking.index];
+        if (!group || selectedIndexes.has(ranking.index)) continue;
+        selected.push({ ...group, rerankScore: ranking.relevanceScore });
+        selectedIndexes.add(ranking.index);
+        if (selected.length >= topK) return selected;
+    }
+
+    for (let i = 0; i < groups.length && selected.length < topK; i++) {
+        if (!selectedIndexes.has(i)) selected.push(groups[i]);
+    }
+
+    return selected;
+}
+
+function formatRerankTagDocument(group) {
+    return `[Tag: ${group.tagId}]\n${normalizedTagData(group)}`;
+}
+
 function formatTagAnswerContext(group) {
-    const data = String(group.tag?.data ?? '')
+    const data = normalizedTagData(group);
+    return `[Tag: ${group.tagId}]\n${data}`;
+}
+
+function normalizedTagData(group) {
+    return String(group.tag?.data ?? '')
         .replace(/[ \t]+\n/g, '\n')
         .replace(/\n{3,}/g, '\n\n')
         .trim();
-    return `[Tag: ${group.tagId}]\n${data}`;
 }
 
 function formatSource(source) {

--- a/src/modules/OpenRouter.js
+++ b/src/modules/OpenRouter.js
@@ -150,7 +150,7 @@ module.exports = class OpenRouter extends require('./Module') {
 
         return requestWithRetry(fn)
             .then((res) => {
-                this.#addOpenRouterApmLabels(transaction, span, res, type);
+                if (type !== 'rerank') this.#addOpenRouterApmLabels(transaction, span, res, type);
                 span?.setOutcome('success');
                 return res;
             })
@@ -164,19 +164,10 @@ module.exports = class OpenRouter extends require('./Module') {
     }
 
     #addOpenRouterApmLabels(transaction, span, res, type) {
-        const model = res.data?.model || (type === 'rerank' ? this.rerankModel : undefined);
-        const provider = res.data?.provider;
-
-        if (model) {
-            transaction?.setLabel(`openrouter.${type}.model`, model);
-            span?.setLabel('openrouter_model', model);
-        }
-        if (provider) {
-            transaction?.setLabel(`openrouter.${type}.provider`, provider);
-            span?.setLabel('openrouter_provider', provider);
-        }
-
-        if (!res.data?.usage) return;
+        transaction?.setLabel(`openrouter.${type}.model`, res.data.model);
+        transaction?.setLabel(`openrouter.${type}.provider`, res.data.provider);
+        span?.setLabel('openrouter_model', res.data.model);
+        span?.setLabel('openrouter_provider', res.data.provider);
 
         const customContext = {};
         customContext[type] = {

--- a/src/modules/OpenRouter.js
+++ b/src/modules/OpenRouter.js
@@ -3,6 +3,7 @@ const axios = require('axios');
 const OPENROUTER_BASE = 'https://openrouter.ai/api/v1';
 const EMBED_TIMEOUT = 30000;
 const CHAT_TIMEOUT = 60000;
+const RERANK_TIMEOUT = 30000;
 const RETRY_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 500;
 
@@ -20,6 +21,7 @@ module.exports = class OpenRouter extends require('./Module') {
         this.apiKey = process.env.OPENROUTER_API_KEY;
         this.embeddingModel = config.embeddingModel || 'openai/text-embedding-3-small';
         this.chatModel = config.chatModel || 'deepseek/deepseek-chat-v3.1';
+        this.rerankModel = config.rerankModel || 'cohere/rerank-4-fast';
         this.maxTokens = config.maxTokens ?? 500;
         this.temperature = config.temperature ?? 0.2;
         this.excludedProviders = normalizeExcludedProviders(config.excludedProviders);
@@ -87,6 +89,29 @@ module.exports = class OpenRouter extends require('./Module') {
         };
     }
 
+    async rerank(query, documents, { topN } = {}) {
+        this.assertConfigured();
+        if (!documents.length) return [];
+
+        const top_n = Math.min(topN ?? documents.length, documents.length);
+        const res = await this.#requestOpenRouter('rerank', () =>
+            axios.post(
+                `${OPENROUTER_BASE}/rerank`,
+                this.buildBody({
+                    model: this.rerankModel,
+                    query,
+                    documents,
+                    top_n,
+                }),
+                {
+                    headers: this.headers(),
+                    timeout: RERANK_TIMEOUT,
+                }
+            )
+        );
+        return parseRerankResults(res.data?.results, documents.length);
+    }
+
     async setChatModel(model) {
         this.chatModel = model;
         await this.bot.setConfiguration(`${this.id}_chat_model`, model);
@@ -114,6 +139,7 @@ module.exports = class OpenRouter extends require('./Module') {
             `${super.getConfigurationOverview()}\n` +
             `- Embedding Model: ${this.embeddingModel}\n` +
             `- Chat Model: ${this.chatModel}\n` +
+            `- Rerank Model: ${this.rerankModel}\n` +
             `- Excluded Providers: ${this.excludedProviders.length ? this.excludedProviders.join(', ') : 'none'}`
         );
     }
@@ -138,10 +164,19 @@ module.exports = class OpenRouter extends require('./Module') {
     }
 
     #addOpenRouterApmLabels(transaction, span, res, type) {
-        transaction?.setLabel(`openrouter.${type}.model`, res.data.model);
-        transaction?.setLabel(`openrouter.${type}.provider`, res.data.provider);
-        span?.setLabel('openrouter_model', res.data.model);
-        span?.setLabel('openrouter_provider', res.data.provider);
+        const model = res.data?.model || (type === 'rerank' ? this.rerankModel : undefined);
+        const provider = res.data?.provider;
+
+        if (model) {
+            transaction?.setLabel(`openrouter.${type}.model`, model);
+            span?.setLabel('openrouter_model', model);
+        }
+        if (provider) {
+            transaction?.setLabel(`openrouter.${type}.provider`, provider);
+            span?.setLabel('openrouter_provider', provider);
+        }
+
+        if (!res.data?.usage) return;
 
         const customContext = {};
         customContext[type] = {
@@ -177,6 +212,23 @@ function isRetryableError(err) {
 function normalizeExcludedProviders(providers) {
     if (!Array.isArray(providers)) return [];
     return providers.map((provider) => String(provider).trim()).filter(Boolean);
+}
+
+function parseRerankResults(results, documentCount) {
+    if (!Array.isArray(results)) return [];
+    return results
+        .map((result) => ({
+            index: Number(result?.index),
+            relevanceScore: Number(result?.relevance_score ?? result?.score),
+        }))
+        .filter(
+            (result) =>
+                Number.isInteger(result.index) &&
+                result.index >= 0 &&
+                result.index < documentCount &&
+                Number.isFinite(result.relevanceScore)
+        )
+        .sort((a, b) => b.relevanceScore - a.relevanceScore);
 }
 
 function delay(ms) {

--- a/src/modules/OpenRouter.js
+++ b/src/modules/OpenRouter.js
@@ -150,7 +150,7 @@ module.exports = class OpenRouter extends require('./Module') {
 
         return requestWithRetry(fn)
             .then((res) => {
-                if (type !== 'rerank') this.#addOpenRouterApmLabels(transaction, span, res, type);
+                this.#addOpenRouterApmLabels(transaction, span, res, type);
                 span?.setOutcome('success');
                 return res;
             })
@@ -164,17 +164,24 @@ module.exports = class OpenRouter extends require('./Module') {
     }
 
     #addOpenRouterApmLabels(transaction, span, res, type) {
-        transaction?.setLabel(`openrouter.${type}.model`, res.data.model);
-        transaction?.setLabel(`openrouter.${type}.provider`, res.data.provider);
-        span?.setLabel('openrouter_model', res.data.model);
-        span?.setLabel('openrouter_provider', res.data.provider);
+        const data = res.data ?? {};
+
+        if (data.model) {
+            transaction?.setLabel(`openrouter.${type}.model`, data.model);
+            span?.setLabel('openrouter_model', data.model);
+        }
+        if (data.provider) {
+            transaction?.setLabel(`openrouter.${type}.provider`, data.provider);
+            span?.setLabel('openrouter_provider', data.provider);
+        }
+        if (!data.usage) return;
 
         const customContext = {};
         customContext[type] = {
-            prompt_tokens: res.data.usage.prompt_tokens,
-            completion_tokens: res.data.usage.completion_tokens,
-            total_tokens: res.data.usage.total_tokens,
-            cost: res.data.usage.cost,
+            prompt_tokens: data.usage.prompt_tokens,
+            completion_tokens: data.usage.completion_tokens,
+            total_tokens: data.usage.total_tokens,
+            cost: data.usage.cost,
         };
         this.elasticapm.apm?.setCustomContext(customContext);
     }


### PR DESCRIPTION
## Summary
- add OpenRouter-owned `/api/v1/rerank` support
- rerank live `snail ask` tag groups from authoritative Mongo `Tag.data`
- make `snail kb find {query}` use the same thresholded candidate pool + authoritative-Tag.data reranking path
- expand first-stage Qdrant candidates with `kb.rerankCandidateLimit`, keep `scoreThreshold` enabled at a lower value (`0.5`), and keep final context limited to top `topK`
- keep APM labeling response-owned: no local-config model/provider fabrication and no rerank-specific skip branch

## Verification
- `SNAIL_WORKTREE=$PWD NODE_PATH=./node_modules node /tmp/snail-rerank-harness.js`
- `node -c src/modules/OpenRouter.js`
- `node -c src/modules/KnowledgeBase.js`
- `node -e "JSON.parse(require('fs').readFileSync('config.json','utf8')); console.log('syntax+config ok')"`
- `./node_modules/.bin/eslint src/modules/OpenRouter.js src/modules/KnowledgeBase.js`
- `./node_modules/.bin/prettier --check src/modules/OpenRouter.js src/modules/KnowledgeBase.js config.json`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improved Search Relevance**
  * Added reranking to knowledge base searches for more relevant results.
  * Expanded candidate retrieval before selecting the best matching content.
  * Added configurable relevance thresholds and reranking limits.

* **Configuration**
  * Added support for selecting a reranking model.
  * Configuration overviews now display reranking settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->