### PR TITLE
fix(kb): render ask tags in description

### DIFF
--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -160,7 +160,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
         if (sources.length) {
             const publicSources = sources.filter((source) => source?.visibility !== 'kb_only');
             if (publicSources.length) {
-                embed.footer = { text: `Tags: ${publicSources.slice(0, 5).map(formatSource).join(', ')}` };
+                embed.description += `\n\n-# Tags: ${publicSources.slice(0, 5).map(formatSource).join(', ')}`;
             }
         }
 


### PR DESCRIPTION
## Summary\n- move Snail ask tag list from the embed footer into the answer embed description\n- render tags after a blank line with Discord subtext markdown\n\n## Verification\n- node --check src/modules/KnowledgeBase.js\n- npx eslint src/modules/KnowledgeBase.js