### PR TITLE
Add KB glossary terms to ask prompts

### DIFF
--- a/src/commands/modules/kb.js
+++ b/src/commands/modules/kb.js
@@ -30,6 +30,9 @@ module.exports = new Command({
         '- `snail kb delete {name}`\n  - Delete a KB-only/private support tag\n' +
         '- `snail kb list`\n  - List KB-only/private support tags\n' +
         '- `snail kb questions {tag}`\n  - Show/edit retrieval questions cached in Mongo for a tag\n' +
+        '- `snail kb term set {id} {meaning}`\n  - Add or update an OwO bot term appended to final ask prompts\n' +
+        '- `snail kb term delete {id}`\n  - Delete an OwO bot term\n' +
+        '- `snail kb term list`\n  - List stored OwO bot terms\n' +
         '- `snail kb exclude {tag...}`\n  - Exclude one or more tags from KB retrieval and delete their Qdrant points\n' +
         '- `snail kb include {tag...}`\n  - Include one or more tags in KB retrieval and sync their Qdrant points\n' +
         '- `snail kb excluded`\n  - List tags excluded from KB retrieval\n' +
@@ -46,6 +49,9 @@ module.exports = new Command({
         'snail kb delete privategems',
         'snail kb list',
         'snail kb questions gems',
+        'snail kb term set dt distorted pets',
+        'snail kb term delete dt',
+        'snail kb term list',
         'snail kb exclude newtr trstart',
         'snail kb include newtr trstart',
         'snail kb excluded',
@@ -86,6 +92,8 @@ module.exports = new Command({
                 return listKbOnlyTags.call(this);
             case 'questions':
                 return showQuestions.call(this, KB);
+            case 'term':
+                return runTerm.call(this, KB);
             case 'exclude':
                 return setTagExcluded.call(this, KB, true);
             case 'include':
@@ -96,7 +104,7 @@ module.exports = new Command({
                 return setModel.call(this, openrouter);
             default:
                 await this.error(
-                    'that is not a valid subcommand! Use `snail kb [status|reindex|reset|find|add|edit|delete|list|questions|exclude|include|excluded|model] {...arguments}`'
+                    'that is not a valid subcommand! Use `snail kb [status|reindex|reset|find|add|edit|delete|list|questions|term|exclude|include|excluded|model] {...arguments}`'
                 );
         }
     },
@@ -662,6 +670,78 @@ function disableComponents(content) {
             component.disabled = true;
         }
     }
+}
+
+async function runTerm(KB) {
+    const action = this.message.args.shift()?.toLowerCase();
+    switch (action) {
+        case 'set':
+            return setKnowledgeTerm.call(this, KB);
+        case 'delete':
+            return deleteKnowledgeTerm.call(this, KB);
+        case 'list':
+            return listKnowledgeTerms.call(this, KB);
+        default:
+            await this.error(
+                'please use `snail kb term set {id} {meaning}`, `snail kb term delete {id}`, or `snail kb term list`.'
+            );
+    }
+}
+
+async function setKnowledgeTerm(KB) {
+    const termId = this.message.args.shift();
+    const meaning = this.message.args.join(' ').trim();
+    if (!termId || !meaning) {
+        await this.error('please provide a term id and meaning! Example: `snail kb term set dt distorted pets`');
+        return;
+    }
+
+    try {
+        const term = await KB.setKnowledgeTerm(termId, meaning);
+        await this.send(`✅ **|** Set OwO bot term \`${term._id}\` = ${term.meaning}`);
+    } catch (err) {
+        console.error('[KB] set term failed:', err);
+        await this.error(`failed to set term: \`${err.message}\``);
+    }
+}
+
+async function deleteKnowledgeTerm(KB) {
+    const termId = this.message.args.shift();
+    if (!termId) {
+        await this.error('please provide a term id! Example: `snail kb term delete dt`');
+        return;
+    }
+
+    try {
+        const result = await KB.deleteKnowledgeTerm(termId);
+        const status = result.deleted ? 'Deleted' : 'No stored term found for';
+        await this.send(`✅ **|** ${status} OwO bot term \`${result._id}\`.`);
+    } catch (err) {
+        console.error('[KB] delete term failed:', err);
+        await this.error(`failed to delete term: \`${err.message}\``);
+    }
+}
+
+async function listKnowledgeTerms(KB) {
+    let terms;
+    try {
+        terms = await KB.listKnowledgeTerms();
+    } catch (err) {
+        console.error('[KB] list terms failed:', err);
+        await this.error(`failed to list terms: \`${err.message}\``);
+        return;
+    }
+
+    const termLines = terms.map((term) => `\`${term._id}\` = ${term.meaning}`).join('\n');
+    const description = terms.length ? termLines.slice(0, 3500) : 'No OwO bot terms are stored.';
+
+    await this.send({
+        embed: {
+            title: 'OwO Bot Terms',
+            color: this.config.embedcolor,
+            description,
+        },
+    });
 }
 
 async function setTagExcluded(KB, excluded) {

--- a/src/databases/mongodb/mongo.js
+++ b/src/databases/mongodb/mongo.js
@@ -19,6 +19,7 @@ class Mongo {
         // I didn't want to @ts-ignore every time I used these...
         this.Channel = undefined;
         this.Config = undefined;
+        this.KnowledgeTerm = undefined;
         this.Quest = undefined;
         this.Tag = undefined;
         this.User = undefined;

--- a/src/databases/mongodb/schemas/KnowledgeTermSchema.js
+++ b/src/databases/mongodb/schemas/KnowledgeTermSchema.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const KnowledgeTermSchema = new mongoose.Schema({
+    _id: String,
+    meaning: String,
+});
+
+module.exports = { name: 'KnowledgeTerm', schema: KnowledgeTermSchema };

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -80,6 +80,10 @@ module.exports = class KnowledgeBase extends require('./Module') {
         return this.bot.snail_db.Tag;
     }
 
+    get KnowledgeTerm() {
+        return this.bot.snail_db.KnowledgeTerm;
+    }
+
     get openrouter() {
         return this.bot.modules.openrouter;
     }
@@ -300,11 +304,9 @@ module.exports = class KnowledgeBase extends require('./Module') {
 
         assertAskBudget(askStartedAt);
         const context = groups.map(formatTagAnswerContext).join('\n\n');
+        const terms = await this.fetchQuestionTerms(question);
 
-        const { content } = await this.openrouter.chat(
-            SYSTEM_PROMPT,
-            `Support notes:\n${context}\n\nUser question:\n${question}`
-        );
+        const { content } = await this.openrouter.chat(SYSTEM_PROMPT, formatAnswerPrompt(context, question, terms));
 
         const sources = groups.map((group) => ({ tagId: group.tagId, visibility: group.visibility }));
         return {
@@ -312,6 +314,42 @@ module.exports = class KnowledgeBase extends require('./Module') {
             sources,
             hits,
         };
+    }
+
+    async fetchQuestionTerms(question) {
+        const termIds = extractTermIds(question);
+        if (!termIds.length) return [];
+
+        const docs = await leanQuery(this.KnowledgeTerm.find({ _id: { $in: termIds } }));
+        const termsById = new Map(docs.map((term) => [String(term._id), term]));
+        return termIds.map((termId) => termsById.get(termId)).filter(Boolean);
+    }
+
+    async setKnowledgeTerm(termId, meaning) {
+        const normalizedTermId = normalizeTermId(termId);
+        const normalizedMeaning = String(meaning ?? '').trim();
+        if (!normalizedTermId) throw new Error('Term id must contain at least one alphanumeric character.');
+        if (!normalizedMeaning) throw new Error('Term meaning cannot be blank.');
+
+        await this.KnowledgeTerm.updateOne(
+            { _id: normalizedTermId },
+            { $set: { meaning: normalizedMeaning } },
+            { upsert: true }
+        );
+        return { _id: normalizedTermId, meaning: normalizedMeaning };
+    }
+
+    async deleteKnowledgeTerm(termId) {
+        const normalizedTermId = normalizeTermId(termId);
+        if (!normalizedTermId) throw new Error('Term id must contain at least one alphanumeric character.');
+
+        const result = await this.KnowledgeTerm.deleteOne({ _id: normalizedTermId });
+        return { _id: normalizedTermId, deleted: result.deletedCount > 0 };
+    }
+
+    async listKnowledgeTerms() {
+        const terms = await leanQuery(this.KnowledgeTerm.find({}));
+        return terms.sort((a, b) => String(a._id).localeCompare(String(b._id)));
     }
 
     async rerankTagGroups(question, groups) {
@@ -785,6 +823,32 @@ module.exports = class KnowledgeBase extends require('./Module') {
 
 function tagFilter(tagId) {
     return { must: [{ key: 'tag_id', match: { value: String(tagId) } }] };
+}
+
+function normalizeTermId(termId) {
+    return String(termId ?? '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]/g, '');
+}
+
+function extractTermIds(question) {
+    const seen = new Set();
+    const termIds = [];
+    for (const match of String(question ?? '').match(/[a-z0-9]+/gi) || []) {
+        const termId = normalizeTermId(match);
+        if (!termId || seen.has(termId)) continue;
+        seen.add(termId);
+        termIds.push(termId);
+    }
+    return termIds;
+}
+
+function formatAnswerPrompt(context, question, terms) {
+    const supportNotes = `Support notes:\n${context}`;
+    if (!terms.length) return `${supportNotes}\n\nUser question:\n${question}`;
+
+    const termLines = terms.map((term) => `${term._id} = ${term.meaning}`).join('\n');
+    return `${supportNotes}\n\nOwO bot terms:\n${termLines}\n\nUser question:\n${question}`;
 }
 
 function isTagKbExcluded(tag) {


### PR DESCRIPTION
## Summary
- add minimal KnowledgeTerm glossary storage for OwO bot terms
- append matched terms to the final Snail KB answer prompt only
- add manager commands for `snail kb term set`, `snail kb term delete`, and `snail kb term list`

## Scope / safety
- retrieval remains unchanged: original question still drives embedding, Qdrant search, and rerank
- no SYSTEM_PROMPT changes
- no aliases, tag mappings, or Qdrant term payloads
- PR #41 / generated-question worktree stayed untouched

## Verification
- `git diff --check`
- `node --check src/modules/KnowledgeBase.js src/commands/modules/kb.js src/databases/mongodb/mongo.js src/databases/mongodb/schemas/KnowledgeTermSchema.js`
- `npx eslint src/modules/KnowledgeBase.js src/commands/modules/kb.js src/databases/mongodb/mongo.js src/databases/mongodb/schemas/KnowledgeTermSchema.js`
- `npx prettier --check src/modules/KnowledgeBase.js src/commands/modules/kb.js src/databases/mongodb/mongo.js src/databases/mongodb/schemas/KnowledgeTermSchema.js`
- temporary prompt harness: `prompt harness ok`

## PDD review
- implementation review: APPROVE
- ponytail review: APPROVE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added knowledge term management through the `snail kb term` commands.
  * Terms can be added, deleted, and listed with confirmations and validation.
  * Knowledge terms are now included when generating answers to relevant questions.
  * Added support for storing and retrieving term meanings in the knowledge base.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->