### PR TITLE
Regenerate KB questions during reindex

### DIFF
--- a/src/commands/modules/kb.js
+++ b/src/commands/modules/kb.js
@@ -24,6 +24,7 @@ module.exports = new Command({
         '- `snail kb status`\n  - Show tag-backed knowledge base sync status and collection info\n' +
         '- `snail kb reindex`\n  - Sync Mongo tags to Qdrant (only changed tag points are re-embedded)\n' +
         '- `snail kb reindex dry`\n  - Show what a reindex would do without making changes\n' +
+        '- `snail kb reindex questions`\n  - Regenerate retrieval questions for all tags, then incrementally sync Qdrant\n' +
         '- `snail kb reset confirm`\n  - Destructively recreate the Qdrant collection, then sync Mongo tags. Remote resets require backup through `ssh hub.corg.network` first.\n' +
         '- `snail kb find {query}`\n  - Search matching tags for manager/debug review\n' +
         '- `snail kb add {name} {data}`\n  - Add a KB-only/private support tag\n' +
@@ -43,6 +44,7 @@ module.exports = new Command({
         'snail kb status',
         'snail kb reindex',
         'snail kb reindex dry',
+        'snail kb reindex questions',
         'snail kb reset confirm',
         'snail kb find how do gems expire',
         'snail kb add privategems Private note for support helpers only',
@@ -183,21 +185,31 @@ function formatSyncProgress(progress) {
 }
 
 async function runReindex(KB) {
-    const dry = this.message.args[0]?.toLowerCase() === 'dry';
+    const modes = new Set(this.message.args.map((arg) => arg.toLowerCase()));
+    const dry = modes.has('dry');
+    const regenerateQuestions = modes.has('questions');
+
+    if (dry && regenerateQuestions) {
+        await this.error('`snail kb reindex questions` regenerates Mongo question caches, so it cannot be combined with `dry`.');
+        return;
+    }
 
     if (KB.syncing) {
         await this.error('a sync is already in progress!');
         return;
     }
 
-    const status = await this.send(`🐌 **|** ${dry ? 'Computing diff' : 'Syncing'}...`);
+    const status = await this.send(
+        `🐌 **|** ${dry ? 'Computing diff' : regenerateQuestions ? 'Regenerating questions and syncing' : 'Syncing'}...`
+    );
 
     try {
-        const summary = await KB.sync({ dryRun: dry });
+        const summary = await KB.sync({ dryRun: dry, regenerateQuestions });
         const embed = {
-            title: dry ? 'Reindex (dry run)' : 'Reindex Complete',
+            title: dry ? 'Reindex (dry run)' : regenerateQuestions ? 'Question Reindex Complete' : 'Reindex Complete',
             color: this.config.embedcolor,
             description:
+                `**Question Cache:** ${summary.regeneratedQuestions ? 'regenerated' : 'preserved'}\n` +
                 `**Added:** ${summary.added}\n` +
                 `**Vector updates:** ${summary.vectorUpdated}\n` +
                 `**Payload updates:** ${summary.metaUpdated}\n` +

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -450,18 +450,20 @@ module.exports = class KnowledgeBase extends require('./Module') {
         return { ...this.syncProgress };
     }
 
-    async sync({ dryRun = false } = {}) {
-        return this.enqueueSyncOperation(() => this.syncUnlocked({ dryRun }));
+    async sync({ dryRun = false, regenerateQuestions = false } = {}) {
+        return this.enqueueSyncOperation(() => this.syncUnlocked({ dryRun, regenerateQuestions }));
     }
 
-    async syncUnlocked({ dryRun = false } = {}) {
+    async syncUnlocked({ dryRun = false, regenerateQuestions = false } = {}) {
         if (this.syncing) throw new Error('A sync is already in progress');
+        if (dryRun && regenerateQuestions) throw new Error('Question regeneration cannot be dry-run');
         if (!this.qdrant) await this.initQdrant();
         if (!dryRun) this.openrouter.assertConfigured();
 
         this.syncing = true;
         this.startSyncProgress(dryRun);
-        const log = (msg) => console.log(`[KB] sync${dryRun ? ' (dry)' : ''}: ${msg}`);
+        const modeLabel = dryRun ? ' (dry)' : regenerateQuestions ? ' (regenerate questions)' : '';
+        const log = (msg) => console.log(`[KB] sync${modeLabel}: ${msg}`);
         try {
             const tags = await this.Tag.find();
             this.updateSyncProgress({ phase: 'planning', totalTags: tags.length });
@@ -474,7 +476,8 @@ module.exports = class KnowledgeBase extends require('./Module') {
                 const tag = tags[i];
                 if (!isTagKbExcluded(tag)) {
                     try {
-                        if (!dryRun) await this.ensureTagKbCache(tag);
+                        if (regenerateQuestions) await this.regenerateTagQuestionCache(tag);
+                        else if (!dryRun) await this.ensureTagKbCache(tag);
                         const tagPoints = this.buildDesiredTagPoints(tag);
                         if (hasQuestionPoint(tagPoints)) tagsWithQuestions += 1;
                         for (const [pointId, point] of tagPoints) desired.set(pointId, point);
@@ -525,6 +528,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
                 totalPoints: desired.size,
                 totalTags: tags.length,
                 dryRun,
+                regeneratedQuestions: regenerateQuestions,
             };
             log(
                 `diff: +${summary.added} add, ~${summary.vectorUpdated} vector, ` +
@@ -584,8 +588,15 @@ module.exports = class KnowledgeBase extends require('./Module') {
             return tag.kb;
         }
 
+        await this.regenerateTagQuestionCache(tag);
+        return tag.kb;
+    }
+
+    async regenerateTagQuestionCache(tag) {
         this.openrouter.assertConfigured();
 
+        const dataHash = tagDataHash(tag.data);
+        const generationHash = tagQuestionGenerationHash(tag, dataHash);
         const questions = await this.generateTagQuestions(tag);
         const kb = buildTagKbCache(tag, questions, dataHash, generationHash);
 
@@ -652,14 +663,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
         const tag = await this.Tag.findById(normalizedTagId);
         if (!tag) return null;
 
-        this.openrouter.assertConfigured();
-
-        const dataHash = tagDataHash(tag.data);
-        const generationHash = tagQuestionGenerationHash(tag, dataHash);
-        const questions = await this.generateTagQuestions(tag);
-        const kb = buildTagKbCache(tag, questions, dataHash, generationHash);
-
-        await this.persistTagKb(tag, kb);
+        await this.regenerateTagQuestionCache(tag);
         let summary;
         if (isTagKbExcluded(tag)) {
             await this.deleteTagByIdUnlocked(normalizedTagId);


### PR DESCRIPTION
## Summary
- Add `snail kb reindex questions` to regenerate retrieval questions for all non-excluded tags
- Reuse the KB module's generation/cache ownership before building the desired Qdrant diff
- Apply the normal incremental Qdrant sync after regeneration instead of resetting the collection

## Verification
- `node -c src/modules/KnowledgeBase.js`
- `node -c src/commands/modules/kb.js`
- `npx --no-install eslint src/modules/KnowledgeBase.js src/commands/modules/kb.js`
- `git diff --check`
