### PR TITLE
Add Snail ask thread conversation history

### DIFF
--- a/src/commands/util/ask.js
+++ b/src/commands/util/ask.js
@@ -38,7 +38,7 @@ module.exports = new Command({
         }
 
         try {
-            const result = await KB.ask(question);
+            const result = await KB.ask(question, { message: this.message });
             await KB.sendAnswer(this.message, result, { question });
         } catch (err) {
             console.error('[KB] ask command failed:', err.message);

--- a/src/modules/CommandHandler.js
+++ b/src/modules/CommandHandler.js
@@ -69,9 +69,7 @@ module.exports = class CommandHandler extends require('./Module') {
 
         // Check if that command has been disabled in this channel
         const disabledChannelId =
-            message.channel?.threadMetadata && message.channel?.parentID
-                ? message.channel.parentID
-                : message.channel.id;
+            command.alias[0] === 'ask' && message.channel?.parentID ? message.channel.parentID : message.channel.id;
         const channel = await this.bot.snail_db.Channel.findById(disabledChannelId);
         if (channel?.disabledCommands.includes(command.alias[0])) {
             if (this.disabledCooldowns[message.author.id + message.command]) return;

--- a/src/modules/CommandHandler.js
+++ b/src/modules/CommandHandler.js
@@ -68,7 +68,11 @@ module.exports = class CommandHandler extends require('./Module') {
         if (!command) return;
 
         // Check if that command has been disabled in this channel
-        const channel = await this.bot.snail_db.Channel.findById(message.channel.id);
+        const disabledChannelId =
+            message.channel?.threadMetadata && message.channel?.parentID
+                ? message.channel.parentID
+                : message.channel.id;
+        const channel = await this.bot.snail_db.Channel.findById(disabledChannelId);
         if (channel?.disabledCommands.includes(command.alias[0])) {
             if (this.disabledCooldowns[message.author.id + message.command]) return;
 

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -3,6 +3,15 @@ const { v5: uuidv5 } = require('uuid');
 
 const { ephemeralInteractionResponse } = require('../utils/sender.js');
 const { Qdrant } = require('../utils/kb.js');
+const {
+    ASK_HISTORY_FETCH_LIMIT,
+    ASK_WARNING_PREFIX,
+    buildAskConversationHistory,
+    formatRetrievalQuery,
+    isAskCommandMessage,
+    isSnailAskAnswerMessage,
+    isSnailAskThreadChannel,
+} = require('./knowledge-base/AskConversationHistory.js');
 
 const SYSTEM_PROMPT =
     'You are Snail, a friendly helper in the OwO Discord bot support server. ' +
@@ -32,10 +41,6 @@ const ASK_FEEDBACK_NEEDS_FIX_ID = 'kb_ask_feedback_needs_fix';
 const EMBED_FIELD_VALUE_LIMIT = 1024;
 const TAG_SYNC_LOG_EVERY = 25;
 const RAW_GENERATION_RESPONSE_LOG_CHARS = 4000;
-const ASK_HISTORY_MAX_TURNS = 5;
-const ASK_HISTORY_MAX_CHARS = 6000;
-const ASK_HISTORY_FETCH_LIMIT = 100;
-const ASK_ANSWER_MARKER = '\u2063\u2063\u2063\u2063\u2063';
 const TAG_QUESTION_PROMPT_VERSION = 'tag-question-v3';
 const TAG_QUESTION_SYSTEM_PROMPT = 'You generate retrieval scaffolding questions for OwO Discord bot support tags.';
 const TAG_QUESTION_PROMPT_SOURCE = `${TAG_QUESTION_PROMPT_VERSION}:${TAG_QUESTION_SYSTEM_PROMPT}`;
@@ -95,6 +100,10 @@ module.exports = class KnowledgeBase extends require('./Module') {
         return this.bot.modules.elasticapm;
     }
 
+    get askCommandPrefixes() {
+        return [this.bot.modules.commandhandler?.prefix, ...(this.bot.config.prefixes || [])].filter(Boolean);
+    }
+
     async onceReady() {
         await super.onceReady();
 
@@ -132,15 +141,19 @@ module.exports = class KnowledgeBase extends require('./Module') {
     async onMessage(message) {
         if (message.author?.bot) return;
         const mentioned = message.mentions?.some((u) => u.id === this.bot.user?.id);
+        if (!mentioned && isAskCommandMessage(message.content, this.askCommandPrefixes)) return;
+
         const askThreadReply = mentioned ? false : await this.isAskThreadReplyMessage(message);
         if (!mentioned && !askThreadReply) return;
 
-        const channel = await this.bot.snail_db.Channel.findById(message.channel.id);
+        const disabledChannelId =
+            isThreadChannel(message.channel) && message.channel.parentID
+                ? message.channel.parentID
+                : message.channel.id;
+        const channel = await this.bot.snail_db.Channel.findById(disabledChannelId);
         if (channel?.disabledCommands.includes('ask')) return;
 
-        const stripped = mentioned
-            ? message.content.replace(new RegExp(`<@!?${this.bot.user.id}>`, 'g'), '').trim()
-            : String(message.content ?? '').trim();
+        const stripped = message.content.replace(new RegExp(`<@!?${this.bot.user.id}>`, 'g'), '').trim();
 
         if (!stripped) return;
         if (stripped.length > 500) return;
@@ -326,7 +339,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
 
         const askStartedAt = Date.now();
         const conversationHistory = await this.fetchAskConversationHistory(message);
-        const retrievalQuery = formatHistoryAwareQuestion(question, conversationHistory);
+        const retrievalQuery = formatRetrievalQuery(question, conversationHistory);
         const vector = await this.embedQuery(retrievalQuery);
 
         assertAskBudget(askStartedAt);
@@ -354,7 +367,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
         const context = groups.map(formatTagAnswerContext).join('\n\n');
         const terms = await this.fetchQuestionTerms(question);
 
-        const { content } = await this.openrouter.responses(
+        const { content } = await this.openrouter.chat(
             SYSTEM_PROMPT,
             formatAnswerPrompt(context, question, terms),
             conversationHistory
@@ -396,7 +409,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
 
         if (!messages.some((historyMessage) => isSnailAskAnswerMessage(historyMessage, this.bot.user?.id))) return [];
 
-        return buildAskConversationHistory(messages, this.bot.user?.id, this.bot.config.prefixes);
+        return buildAskConversationHistory(messages, this.bot.user?.id, this.askCommandPrefixes);
     }
 
     async isAskThreadReplyMessage(message) {
@@ -993,161 +1006,6 @@ function extractTermIds(question) {
     return termIds;
 }
 
-function formatHistoryAwareQuestion(question, history) {
-    const historyText = formatHistoryForPrompt(history);
-    if (!historyText) return question;
-    return `Previous ask conversation:\n${historyText}\n\nCurrent user question:\n${question}`;
-}
-
-function formatHistoryForPrompt(history) {
-    return (history || [])
-        .map((item) => `${item.role === 'assistant' ? 'Snail' : 'User'}: ${String(item.content ?? '').trim()}`)
-        .filter((line) => !line.endsWith(':'))
-        .join('\n');
-}
-
-function buildAskConversationHistory(messages, botUserId, prefixes = []) {
-    const chronological = [...(messages || [])].sort(compareDiscordMessageIds);
-    const askAnswerMessageIds = new Set();
-    const turns = [];
-    let pendingUser = null;
-
-    for (const message of chronological) {
-        if (isBotMessage(message, botUserId)) {
-            if (pendingUser && isSnailAskAnswerMessage(message, botUserId)) {
-                askAnswerMessageIds.add(String(message.id));
-                turns.push({
-                    user: pendingUser,
-                    assistant: { id: message.id, content: cleanAskAnswerContent(message.content) },
-                });
-                pendingUser = null;
-            } else if (isSnailAskAnswerMessage(message, botUserId)) {
-                askAnswerMessageIds.add(String(message.id));
-                turns.push({ assistant: { id: message.id, content: cleanAskAnswerContent(message.content) } });
-            }
-            continue;
-        }
-
-        if (isAskFlowUserMessage(message, botUserId, askAnswerMessageIds, prefixes)) {
-            pendingUser = cleanUserMessageContent(message.content, botUserId);
-        }
-    }
-
-    return capAskHistory(turns);
-}
-
-function capAskHistory(turns) {
-    const recentTurns = turns.slice(-ASK_HISTORY_MAX_TURNS);
-    const capped = [];
-    let chars = 0;
-
-    for (let i = recentTurns.length - 1; i >= 0; i--) {
-        const turn = recentTurns[i];
-        const pair = [
-            { role: 'user', content: turn.user },
-            { role: 'assistant', id: turn.assistant?.id, content: turn.assistant?.content },
-        ].filter((item) => item.content);
-        const pairChars = pair.reduce((total, item) => total + item.content.length, 0);
-        if (capped.length && chars + pairChars > ASK_HISTORY_MAX_CHARS) break;
-        if (!capped.length && pairChars > ASK_HISTORY_MAX_CHARS) {
-            const budget = Math.floor(ASK_HISTORY_MAX_CHARS / 2);
-            capped.unshift(
-                { role: 'user', content: truncateForHistory(turn.user, budget) },
-                {
-                    role: 'assistant',
-                    id: turn.assistant?.id,
-                    content: truncateForHistory(turn.assistant?.content, budget),
-                }
-            );
-            break;
-        }
-        capped.unshift(...pair);
-        chars += pairChars;
-    }
-
-    return capped;
-}
-
-function isAskFlowUserMessage(message, botUserId, askAnswerMessageIds, prefixes) {
-    if (message.author?.bot) return false;
-    if (isAskCommandMessage(message.content, prefixes)) return true;
-    if (mentionsBot(message, botUserId)) return true;
-    return isReplyToSnailAskAnswerMessage(message, botUserId, askAnswerMessageIds);
-}
-
-function isAskCommandMessage(content, prefixes = []) {
-    const text = String(content ?? '')
-        .trim()
-        .toLowerCase();
-    if (/^snail\s+ask(?:\s|$)/.test(text)) return true;
-
-    return (prefixes || [])
-        .map((prefix) =>
-            String(prefix ?? '')
-                .trim()
-                .toLowerCase()
-        )
-        .filter(Boolean)
-        .some((prefix) => text.startsWith(`${prefix} ask `) || text === `${prefix} ask`);
-}
-
-function mentionsBot(message, botUserId) {
-    if (!botUserId) return false;
-    if (message.mentions?.some((user) => user.id === botUserId)) return true;
-    return new RegExp(`<@!?${botUserId}>`).test(String(message.content ?? ''));
-}
-
-function isReplyToSnailAskAnswerMessage(message, botUserId, askAnswerMessageIds) {
-    if (!botUserId) return false;
-    const referencedMessageId = message.messageReference?.messageID || message.messageReference?.message_id;
-    if (referencedMessageId && askAnswerMessageIds.has(String(referencedMessageId))) return true;
-    return isSnailAskAnswerMessage(message.referencedMessage, botUserId);
-}
-
-function isSnailAskAnswerMessage(message, botUserId) {
-    if (!isBotMessage(message, botUserId)) return false;
-    const content = String(message.content ?? '');
-    return content.includes(ASK_ANSWER_MARKER) || content.startsWith('> -# ⚠️ Snail may be incorrect.');
-}
-
-function isBotMessage(message, botUserId) {
-    return Boolean(botUserId && message.author?.id === botUserId);
-}
-
-function cleanUserMessageContent(content, botUserId) {
-    return String(content ?? '')
-        .replace(new RegExp(`<@!?${botUserId}>`, 'g'), '@Snail')
-        .replace(/\s+/g, ' ')
-        .trim();
-}
-
-function cleanAskAnswerContent(content) {
-    return String(content ?? '')
-        .split(ASK_ANSWER_MARKER)
-        .join('')
-        .replace(/^> -# ⚠️ Snail may be incorrect\. This feature is still a work in progress!\s*/i, '')
-        .replace(/\n\n> -# Tags:.*$/s, '')
-        .trim();
-}
-
-function truncateForHistory(content, maxChars) {
-    const text = String(content ?? '').trim();
-    if (text.length <= maxChars) return text;
-    return `${text.slice(0, Math.max(0, maxChars - 1))}…`;
-}
-
-function compareDiscordMessageIds(a, b) {
-    try {
-        const left = BigInt(a.id);
-        const right = BigInt(b.id);
-        if (left < right) return -1;
-        if (left > right) return 1;
-        return 0;
-    } catch {
-        return String(a.id).localeCompare(String(b.id));
-    }
-}
-
 function formatAnswerPrompt(context, question, terms) {
     const supportNotes = `Support notes:\n${context}`;
     if (!terms.length) return `${supportNotes}\n\nUser question:\n${question}`;
@@ -1657,18 +1515,8 @@ function isThreadChannel(channel) {
     return Boolean(channel?.threadMetadata || (channel?.parentID && !channel?.createThreadWithMessage));
 }
 
-function isSnailAskThreadChannel(channel, botUserId) {
-    return (
-        isThreadChannel(channel) &&
-        Boolean(botUserId && channel?.ownerID === botUserId) &&
-        String(channel?.name ?? '')
-            .toLowerCase()
-            .startsWith('snail ask')
-    );
-}
-
 function buildPlainAnswerContent(answer, sources) {
-    let content = `> -# ⚠️ Snail may be incorrect. This feature is still a work in progress!${ASK_ANSWER_MARKER}\n\n`;
+    let content = `${ASK_WARNING_PREFIX}\n\n`;
     content += String(answer ?? '');
     const publicSources = (sources ?? []).filter((source) => source?.visibility !== 'kb_only');
 

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -32,6 +32,10 @@ const ASK_FEEDBACK_NEEDS_FIX_ID = 'kb_ask_feedback_needs_fix';
 const EMBED_FIELD_VALUE_LIMIT = 1024;
 const TAG_SYNC_LOG_EVERY = 25;
 const RAW_GENERATION_RESPONSE_LOG_CHARS = 4000;
+const ASK_HISTORY_MAX_TURNS = 5;
+const ASK_HISTORY_MAX_CHARS = 6000;
+const ASK_HISTORY_FETCH_LIMIT = 100;
+const ASK_ANSWER_MARKER = '\u2063\u2063\u2063\u2063\u2063';
 const TAG_QUESTION_PROMPT_VERSION = 'tag-question-v3';
 const TAG_QUESTION_SYSTEM_PROMPT = 'You generate retrieval scaffolding questions for OwO Discord bot support tags.';
 const TAG_QUESTION_PROMPT_SOURCE = `${TAG_QUESTION_PROMPT_VERSION}:${TAG_QUESTION_SYSTEM_PROMPT}`;
@@ -127,12 +131,16 @@ module.exports = class KnowledgeBase extends require('./Module') {
 
     async onMessage(message) {
         if (message.author?.bot) return;
-        if (!message.mentions?.some((u) => u.id === this.bot.user?.id)) return;
+        const mentioned = message.mentions?.some((u) => u.id === this.bot.user?.id);
+        const askThreadReply = mentioned ? false : await this.isAskThreadReplyMessage(message);
+        if (!mentioned && !askThreadReply) return;
 
         const channel = await this.bot.snail_db.Channel.findById(message.channel.id);
         if (channel?.disabledCommands.includes('ask')) return;
 
-        const stripped = message.content.replace(new RegExp(`<@!?${this.bot.user.id}>`, 'g'), '').trim();
+        const stripped = mentioned
+            ? message.content.replace(new RegExp(`<@!?${this.bot.user.id}>`, 'g'), '').trim()
+            : String(message.content ?? '').trim();
 
         if (!stripped) return;
         if (stripped.length > 500) return;
@@ -140,7 +148,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
         await message.channel.sendTyping().catch(() => {});
 
         try {
-            const result = await this.ask(stripped);
+            const result = await this.ask(stripped, { message });
             await this.sendAnswer(message, result, { question: stripped });
         } catch (err) {
             console.error('[KB] mention ask failed:', err.message);
@@ -296,12 +304,12 @@ module.exports = class KnowledgeBase extends require('./Module') {
         return vector;
     }
 
-    async ask(question) {
+    async ask(question, { message } = {}) {
         const transaction = this.elasticApm.startTransaction('snail.ask.fetch', 'bot');
 
         try {
             transaction?.setLabel('question_length', question.length);
-            const result = await this.fetchAskAnswer(question);
+            const result = await this.fetchAskAnswer(question, { message });
             transaction?.setOutcome('success');
             return result;
         } catch (err) {
@@ -313,11 +321,13 @@ module.exports = class KnowledgeBase extends require('./Module') {
         }
     }
 
-    async fetchAskAnswer(question) {
+    async fetchAskAnswer(question, { message } = {}) {
         if (!this.qdrant) await this.initQdrant();
 
         const askStartedAt = Date.now();
-        const vector = await this.embedQuery(question);
+        const conversationHistory = await this.fetchAskConversationHistory(message);
+        const retrievalQuery = formatHistoryAwareQuestion(question, conversationHistory);
+        const vector = await this.embedQuery(retrievalQuery);
 
         assertAskBudget(askStartedAt);
         const rawHits = await this.qdrant.search(this.collection, {
@@ -329,7 +339,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
 
         assertAskBudget(askStartedAt);
         const candidateGroups = await this.materializeTagGroups(groupHitsByTag(rawHits));
-        const groups = await this.rerankTagGroups(question, candidateGroups);
+        const groups = await this.rerankTagGroups(retrievalQuery, candidateGroups);
         const hits = groups.flatMap((group) => group.hits);
 
         if (!groups.length) {
@@ -344,15 +354,80 @@ module.exports = class KnowledgeBase extends require('./Module') {
         const context = groups.map(formatTagAnswerContext).join('\n\n');
         const terms = await this.fetchQuestionTerms(question);
 
-        const { content } = await this.openrouter.chat(SYSTEM_PROMPT, formatAnswerPrompt(context, question, terms));
+        const { content } = await this.openrouter.responses(
+            SYSTEM_PROMPT,
+            formatAnswerPrompt(context, question, terms),
+            conversationHistory
+        );
         const answerResponse = parseAnswerResponse(content);
         const sources = selectAnswerSources(groups, answerResponse);
 
         return {
-            answer: answerResponse.answer || "I don't know that one yet — please ask a helper or rephrase your question.",
+            answer:
+                answerResponse.answer || "I don't know that one yet — please ask a helper or rephrase your question.",
             sources,
             hits,
         };
+    }
+
+    async fetchAskConversationHistory(message) {
+        if (!message || !isThreadChannel(message.channel)) return [];
+        if (!isSnailAskThreadChannel(message.channel, this.bot.user?.id)) return [];
+
+        let messages;
+        try {
+            messages = await message.channel.getMessages(ASK_HISTORY_FETCH_LIMIT, message.id);
+        } catch (err) {
+            console.warn('[KB] ask history fetch failed:', err.message);
+            return [];
+        }
+
+        const starterMessage = await this.fetchAskThreadStarterMessage(message.channel);
+        if (starterMessage) messages.push(starterMessage);
+
+        const referencedMessageId = message.messageReference?.messageID || message.messageReference?.message_id;
+        if (
+            referencedMessageId &&
+            !messages.some((candidate) => String(candidate.id) === String(referencedMessageId))
+        ) {
+            const referenced = await this.fetchReferencedMessage(message, referencedMessageId);
+            if (referenced) messages.push(referenced);
+        }
+
+        if (!messages.some((historyMessage) => isSnailAskAnswerMessage(historyMessage, this.bot.user?.id))) return [];
+
+        return buildAskConversationHistory(messages, this.bot.user?.id, this.bot.config.prefixes);
+    }
+
+    async isAskThreadReplyMessage(message) {
+        if (!message || !isSnailAskThreadChannel(message.channel, this.bot.user?.id)) return false;
+        const referencedMessageId = message.messageReference?.messageID || message.messageReference?.message_id;
+        if (!referencedMessageId) return false;
+
+        const referenced = await this.fetchReferencedMessage(message, referencedMessageId);
+        return isSnailAskAnswerMessage(referenced, this.bot.user?.id);
+    }
+
+    async fetchReferencedMessage(message, referencedMessageId) {
+        if (message.referencedMessage && String(message.referencedMessage.id) === String(referencedMessageId)) {
+            return message.referencedMessage;
+        }
+        try {
+            return await message.channel.getMessage(referencedMessageId);
+        } catch (err) {
+            console.warn('[KB] ask reply provenance fetch failed:', err.message);
+        }
+    }
+
+    async fetchAskThreadStarterMessage(channel) {
+        const parent = this.bot.getChannel(channel?.parentID);
+        if (!parent || typeof parent.getMessage !== 'function' || !channel?.id) return;
+
+        try {
+            return await parent.getMessage(channel.id);
+        } catch (err) {
+            console.warn('[KB] ask thread starter fetch failed:', err.message);
+        }
     }
 
     async fetchQuestionTerms(question) {
@@ -918,6 +993,161 @@ function extractTermIds(question) {
     return termIds;
 }
 
+function formatHistoryAwareQuestion(question, history) {
+    const historyText = formatHistoryForPrompt(history);
+    if (!historyText) return question;
+    return `Previous ask conversation:\n${historyText}\n\nCurrent user question:\n${question}`;
+}
+
+function formatHistoryForPrompt(history) {
+    return (history || [])
+        .map((item) => `${item.role === 'assistant' ? 'Snail' : 'User'}: ${String(item.content ?? '').trim()}`)
+        .filter((line) => !line.endsWith(':'))
+        .join('\n');
+}
+
+function buildAskConversationHistory(messages, botUserId, prefixes = []) {
+    const chronological = [...(messages || [])].sort(compareDiscordMessageIds);
+    const askAnswerMessageIds = new Set();
+    const turns = [];
+    let pendingUser = null;
+
+    for (const message of chronological) {
+        if (isBotMessage(message, botUserId)) {
+            if (pendingUser && isSnailAskAnswerMessage(message, botUserId)) {
+                askAnswerMessageIds.add(String(message.id));
+                turns.push({
+                    user: pendingUser,
+                    assistant: { id: message.id, content: cleanAskAnswerContent(message.content) },
+                });
+                pendingUser = null;
+            } else if (isSnailAskAnswerMessage(message, botUserId)) {
+                askAnswerMessageIds.add(String(message.id));
+                turns.push({ assistant: { id: message.id, content: cleanAskAnswerContent(message.content) } });
+            }
+            continue;
+        }
+
+        if (isAskFlowUserMessage(message, botUserId, askAnswerMessageIds, prefixes)) {
+            pendingUser = cleanUserMessageContent(message.content, botUserId);
+        }
+    }
+
+    return capAskHistory(turns);
+}
+
+function capAskHistory(turns) {
+    const recentTurns = turns.slice(-ASK_HISTORY_MAX_TURNS);
+    const capped = [];
+    let chars = 0;
+
+    for (let i = recentTurns.length - 1; i >= 0; i--) {
+        const turn = recentTurns[i];
+        const pair = [
+            { role: 'user', content: turn.user },
+            { role: 'assistant', id: turn.assistant?.id, content: turn.assistant?.content },
+        ].filter((item) => item.content);
+        const pairChars = pair.reduce((total, item) => total + item.content.length, 0);
+        if (capped.length && chars + pairChars > ASK_HISTORY_MAX_CHARS) break;
+        if (!capped.length && pairChars > ASK_HISTORY_MAX_CHARS) {
+            const budget = Math.floor(ASK_HISTORY_MAX_CHARS / 2);
+            capped.unshift(
+                { role: 'user', content: truncateForHistory(turn.user, budget) },
+                {
+                    role: 'assistant',
+                    id: turn.assistant?.id,
+                    content: truncateForHistory(turn.assistant?.content, budget),
+                }
+            );
+            break;
+        }
+        capped.unshift(...pair);
+        chars += pairChars;
+    }
+
+    return capped;
+}
+
+function isAskFlowUserMessage(message, botUserId, askAnswerMessageIds, prefixes) {
+    if (message.author?.bot) return false;
+    if (isAskCommandMessage(message.content, prefixes)) return true;
+    if (mentionsBot(message, botUserId)) return true;
+    return isReplyToSnailAskAnswerMessage(message, botUserId, askAnswerMessageIds);
+}
+
+function isAskCommandMessage(content, prefixes = []) {
+    const text = String(content ?? '')
+        .trim()
+        .toLowerCase();
+    if (/^snail\s+ask(?:\s|$)/.test(text)) return true;
+
+    return (prefixes || [])
+        .map((prefix) =>
+            String(prefix ?? '')
+                .trim()
+                .toLowerCase()
+        )
+        .filter(Boolean)
+        .some((prefix) => text.startsWith(`${prefix} ask `) || text === `${prefix} ask`);
+}
+
+function mentionsBot(message, botUserId) {
+    if (!botUserId) return false;
+    if (message.mentions?.some((user) => user.id === botUserId)) return true;
+    return new RegExp(`<@!?${botUserId}>`).test(String(message.content ?? ''));
+}
+
+function isReplyToSnailAskAnswerMessage(message, botUserId, askAnswerMessageIds) {
+    if (!botUserId) return false;
+    const referencedMessageId = message.messageReference?.messageID || message.messageReference?.message_id;
+    if (referencedMessageId && askAnswerMessageIds.has(String(referencedMessageId))) return true;
+    return isSnailAskAnswerMessage(message.referencedMessage, botUserId);
+}
+
+function isSnailAskAnswerMessage(message, botUserId) {
+    if (!isBotMessage(message, botUserId)) return false;
+    const content = String(message.content ?? '');
+    return content.includes(ASK_ANSWER_MARKER) || content.startsWith('> -# ⚠️ Snail may be incorrect.');
+}
+
+function isBotMessage(message, botUserId) {
+    return Boolean(botUserId && message.author?.id === botUserId);
+}
+
+function cleanUserMessageContent(content, botUserId) {
+    return String(content ?? '')
+        .replace(new RegExp(`<@!?${botUserId}>`, 'g'), '@Snail')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function cleanAskAnswerContent(content) {
+    return String(content ?? '')
+        .split(ASK_ANSWER_MARKER)
+        .join('')
+        .replace(/^> -# ⚠️ Snail may be incorrect\. This feature is still a work in progress!\s*/i, '')
+        .replace(/\n\n> -# Tags:.*$/s, '')
+        .trim();
+}
+
+function truncateForHistory(content, maxChars) {
+    const text = String(content ?? '').trim();
+    if (text.length <= maxChars) return text;
+    return `${text.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function compareDiscordMessageIds(a, b) {
+    try {
+        const left = BigInt(a.id);
+        const right = BigInt(b.id);
+        if (left < right) return -1;
+        if (left > right) return 1;
+        return 0;
+    } catch {
+        return String(a.id).localeCompare(String(b.id));
+    }
+}
+
 function formatAnswerPrompt(context, question, terms) {
     const supportNotes = `Support notes:\n${context}`;
     if (!terms.length) return `${supportNotes}\n\nUser question:\n${question}`;
@@ -1427,8 +1657,18 @@ function isThreadChannel(channel) {
     return Boolean(channel?.threadMetadata || (channel?.parentID && !channel?.createThreadWithMessage));
 }
 
+function isSnailAskThreadChannel(channel, botUserId) {
+    return (
+        isThreadChannel(channel) &&
+        Boolean(botUserId && channel?.ownerID === botUserId) &&
+        String(channel?.name ?? '')
+            .toLowerCase()
+            .startsWith('snail ask')
+    );
+}
+
 function buildPlainAnswerContent(answer, sources) {
-    let content = `> -# ⚠️ Snail may be incorrect. This feature is still a work in progress!\n\n`
+    let content = `> -# ⚠️ Snail may be incorrect. This feature is still a work in progress!${ASK_ANSWER_MARKER}\n\n`;
     content += String(answer ?? '');
     const publicSources = (sources ?? []).filter((source) => source?.visibility !== 'kb_only');
 

--- a/src/modules/OpenRouter.js
+++ b/src/modules/OpenRouter.js
@@ -3,6 +3,7 @@ const axios = require('axios');
 const OPENROUTER_BASE = 'https://openrouter.ai/api/v1';
 const EMBED_TIMEOUT = 30000;
 const CHAT_TIMEOUT = 60000;
+const RESPONSES_TIMEOUT = 60000;
 const RERANK_TIMEOUT = 30000;
 const RETRY_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 500;
@@ -86,6 +87,31 @@ module.exports = class OpenRouter extends require('./Module') {
         return {
             content: String(res.data?.choices?.[0]?.message?.content ?? '').trim(),
             usage: res.data.usage,
+        };
+    }
+
+    async responses(systemPrompt, userPrompt, history = []) {
+        this.assertConfigured();
+
+        const res = await this.#requestOpenRouter('responses', () =>
+            axios.post(
+                `${OPENROUTER_BASE}/responses`,
+                this.buildBody({
+                    model: this.chatModel,
+                    instructions: systemPrompt,
+                    input: buildResponsesInput(history, userPrompt),
+                    max_output_tokens: this.maxTokens,
+                    temperature: this.temperature,
+                }),
+                {
+                    headers: this.headers(),
+                    timeout: RESPONSES_TIMEOUT,
+                }
+            )
+        );
+        return {
+            content: parseResponsesOutputText(res.data).trim(),
+            usage: normalizeUsage(res.data.usage),
         };
     }
 
@@ -174,15 +200,11 @@ module.exports = class OpenRouter extends require('./Module') {
             transaction?.setLabel(`openrouter.${type}.provider`, data.provider);
             span?.setLabel('openrouter_provider', data.provider);
         }
-        if (!data.usage) return;
+        const usage = normalizeUsage(data.usage);
+        if (!usage) return;
 
         const customContext = {};
-        customContext[type] = {
-            prompt_tokens: data.usage.prompt_tokens,
-            completion_tokens: data.usage.completion_tokens,
-            total_tokens: data.usage.total_tokens,
-            cost: data.usage.cost,
-        };
+        customContext[type] = usage;
         this.elasticapm.apm?.setCustomContext(customContext);
     }
 };
@@ -227,6 +249,63 @@ function parseRerankResults(results, documentCount) {
                 Number.isFinite(result.relevanceScore)
         )
         .sort((a, b) => b.relevanceScore - a.relevanceScore);
+}
+
+function buildResponsesInput(history, userPrompt) {
+    const input = [];
+    for (let i = 0; i < (history || []).length; i++) {
+        const item = history[i];
+        const role = item?.role === 'assistant' ? 'assistant' : 'user';
+        input.push(toResponsesMessage(role, item?.content, item?.id || `history_${i}`));
+    }
+    input.push(toResponsesMessage('user', userPrompt));
+    return input;
+}
+
+function toResponsesMessage(role, text, id) {
+    const contentType = role === 'assistant' ? 'output_text' : 'input_text';
+    const message = {
+        type: 'message',
+        role,
+        content: [
+            {
+                type: contentType,
+                text: String(text ?? ''),
+            },
+        ],
+    };
+    if (role === 'assistant') {
+        message.id = toResponsesMessageId(id);
+        message.status = 'completed';
+        message.content[0].annotations = [];
+    }
+    return message;
+}
+
+function toResponsesMessageId(id) {
+    return `msg_${String(id ?? 'history').replace(/[^a-zA-Z0-9_-]/g, '_')}`;
+}
+
+function parseResponsesOutputText(data) {
+    if (typeof data?.output_text === 'string') return data.output_text;
+
+    const parts = [];
+    for (const item of data?.output || []) {
+        for (const content of item?.content || []) {
+            if (typeof content?.text === 'string') parts.push(content.text);
+        }
+    }
+    return parts.join('');
+}
+
+function normalizeUsage(usage) {
+    if (!usage) return;
+    return {
+        prompt_tokens: usage.prompt_tokens ?? usage.input_tokens,
+        completion_tokens: usage.completion_tokens ?? usage.output_tokens,
+        total_tokens: usage.total_tokens,
+        cost: usage.cost,
+    };
 }
 
 function delay(ms) {

--- a/src/modules/OpenRouter.js
+++ b/src/modules/OpenRouter.js
@@ -3,7 +3,6 @@ const axios = require('axios');
 const OPENROUTER_BASE = 'https://openrouter.ai/api/v1';
 const EMBED_TIMEOUT = 30000;
 const CHAT_TIMEOUT = 60000;
-const RESPONSES_TIMEOUT = 60000;
 const RERANK_TIMEOUT = 30000;
 const RETRY_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 500;
@@ -63,7 +62,7 @@ module.exports = class OpenRouter extends require('./Module') {
         return res.data.data.map((d) => d.embedding);
     }
 
-    async chat(systemPrompt, userPrompt) {
+    async chat(systemPrompt, userPrompt, history = []) {
         this.assertConfigured();
 
         const res = await this.#requestOpenRouter('chat', () =>
@@ -71,10 +70,7 @@ module.exports = class OpenRouter extends require('./Module') {
                 `${OPENROUTER_BASE}/chat/completions`,
                 this.buildBody({
                     model: this.chatModel,
-                    messages: [
-                        { role: 'system', content: systemPrompt },
-                        { role: 'user', content: userPrompt },
-                    ],
+                    messages: buildChatMessages(systemPrompt, userPrompt, history),
                     max_tokens: this.maxTokens,
                     temperature: this.temperature,
                 }),
@@ -87,31 +83,6 @@ module.exports = class OpenRouter extends require('./Module') {
         return {
             content: String(res.data?.choices?.[0]?.message?.content ?? '').trim(),
             usage: res.data.usage,
-        };
-    }
-
-    async responses(systemPrompt, userPrompt, history = []) {
-        this.assertConfigured();
-
-        const res = await this.#requestOpenRouter('responses', () =>
-            axios.post(
-                `${OPENROUTER_BASE}/responses`,
-                this.buildBody({
-                    model: this.chatModel,
-                    instructions: systemPrompt,
-                    input: buildResponsesInput(history, userPrompt),
-                    max_output_tokens: this.maxTokens,
-                    temperature: this.temperature,
-                }),
-                {
-                    headers: this.headers(),
-                    timeout: RESPONSES_TIMEOUT,
-                }
-            )
-        );
-        return {
-            content: parseResponsesOutputText(res.data).trim(),
-            usage: normalizeUsage(res.data.usage),
         };
     }
 
@@ -200,11 +171,15 @@ module.exports = class OpenRouter extends require('./Module') {
             transaction?.setLabel(`openrouter.${type}.provider`, data.provider);
             span?.setLabel('openrouter_provider', data.provider);
         }
-        const usage = normalizeUsage(data.usage);
-        if (!usage) return;
+        if (!data.usage) return;
 
         const customContext = {};
-        customContext[type] = usage;
+        customContext[type] = {
+            prompt_tokens: data.usage.prompt_tokens,
+            completion_tokens: data.usage.completion_tokens,
+            total_tokens: data.usage.total_tokens,
+            cost: data.usage.cost,
+        };
         this.elasticapm.apm?.setCustomContext(customContext);
     }
 };
@@ -251,61 +226,15 @@ function parseRerankResults(results, documentCount) {
         .sort((a, b) => b.relevanceScore - a.relevanceScore);
 }
 
-function buildResponsesInput(history, userPrompt) {
-    const input = [];
-    for (let i = 0; i < (history || []).length; i++) {
-        const item = history[i];
-        const role = item?.role === 'assistant' ? 'assistant' : 'user';
-        input.push(toResponsesMessage(role, item?.content, item?.id || `history_${i}`));
-    }
-    input.push(toResponsesMessage('user', userPrompt));
-    return input;
-}
-
-function toResponsesMessage(role, text, id) {
-    const contentType = role === 'assistant' ? 'output_text' : 'input_text';
-    const message = {
-        type: 'message',
-        role,
-        content: [
-            {
-                type: contentType,
-                text: String(text ?? ''),
-            },
-        ],
-    };
-    if (role === 'assistant') {
-        message.id = toResponsesMessageId(id);
-        message.status = 'completed';
-        message.content[0].annotations = [];
-    }
-    return message;
-}
-
-function toResponsesMessageId(id) {
-    return `msg_${String(id ?? 'history').replace(/[^a-zA-Z0-9_-]/g, '_')}`;
-}
-
-function parseResponsesOutputText(data) {
-    if (typeof data?.output_text === 'string') return data.output_text;
-
-    const parts = [];
-    for (const item of data?.output || []) {
-        for (const content of item?.content || []) {
-            if (typeof content?.text === 'string') parts.push(content.text);
-        }
-    }
-    return parts.join('');
-}
-
-function normalizeUsage(usage) {
-    if (!usage) return;
-    return {
-        prompt_tokens: usage.prompt_tokens ?? usage.input_tokens,
-        completion_tokens: usage.completion_tokens ?? usage.output_tokens,
-        total_tokens: usage.total_tokens,
-        cost: usage.cost,
-    };
+function buildChatMessages(systemPrompt, userPrompt, history = []) {
+    return [
+        { role: 'system', content: systemPrompt },
+        ...(history || []).map((item) => ({
+            role: item?.role === 'assistant' ? 'assistant' : 'user',
+            content: String(item?.content ?? ''),
+        })),
+        { role: 'user', content: userPrompt },
+    ];
 }
 
 function delay(ms) {

--- a/src/modules/knowledge-base/AskConversationHistory.js
+++ b/src/modules/knowledge-base/AskConversationHistory.js
@@ -17,27 +17,33 @@ function isSnailAskThreadChannel(channel, botUserId) {
 function buildAskConversationHistory(messages, botUserId, prefixes = []) {
     const chronological = [...(messages || [])].sort(compareDiscordMessageIds);
     const askAnswerMessageIds = new Set();
+    const pendingUsers = [];
     const turns = [];
-    let pendingUser = null;
 
     for (const message of chronological) {
         if (isBotMessage(message, botUserId)) {
-            if (pendingUser && isSnailAskAnswerMessage(message, botUserId)) {
-                askAnswerMessageIds.add(String(message.id));
-                turns.push({
-                    user: pendingUser,
-                    assistant: cleanAskAnswerContent(message.content),
-                });
-                pendingUser = null;
-            } else if (isSnailAskAnswerMessage(message, botUserId)) {
-                askAnswerMessageIds.add(String(message.id));
-                turns.push({ assistant: cleanAskAnswerContent(message.content) });
-            }
+            if (!isSnailAskAnswerMessage(message, botUserId)) continue;
+
+            askAnswerMessageIds.add(String(message.id));
+            const referencedUserId = getReferencedMessageId(message);
+            const referencedUserIndex = referencedUserId
+                ? pendingUsers.findIndex((pending) => pending.id === String(referencedUserId))
+                : -1;
+            const pendingUser =
+                referencedUserIndex >= 0 ? pendingUsers.splice(referencedUserIndex, 1)[0] : pendingUsers.shift();
+
+            turns.push({
+                user: pendingUser?.content,
+                assistant: cleanAskAnswerContent(message.content),
+            });
             continue;
         }
 
         if (isAskFlowUserMessage(message, botUserId, askAnswerMessageIds, prefixes)) {
-            pendingUser = cleanUserMessageContent(message.content, botUserId, prefixes);
+            pendingUsers.push({
+                id: String(message.id),
+                content: cleanUserMessageContent(message.content, botUserId, prefixes),
+            });
         }
     }
 
@@ -86,8 +92,9 @@ function formatHistoryForPrompt(history, maxChars) {
 
         const line = `${item.role === 'assistant' ? 'Snail' : 'User'}: ${content}`;
         if (lines.length && chars + line.length > maxChars) break;
-        lines.unshift(truncateForHistory(line, maxChars));
-        chars += line.length;
+        const truncatedLine = truncateForHistory(line, maxChars);
+        lines.unshift(truncatedLine);
+        chars += truncatedLine.length;
     }
 
     return lines.join('\n');
@@ -131,9 +138,13 @@ function isThreadChannel(channel) {
 
 function isReplyToSnailAskAnswerMessage(message, botUserId, askAnswerMessageIds) {
     if (!botUserId) return false;
-    const referencedMessageId = message.messageReference?.messageID || message.messageReference?.message_id;
+    const referencedMessageId = getReferencedMessageId(message);
     if (referencedMessageId && askAnswerMessageIds.has(String(referencedMessageId))) return true;
     return isSnailAskAnswerMessage(message.referencedMessage, botUserId);
+}
+
+function getReferencedMessageId(message) {
+    return message?.messageReference?.messageID || message?.messageReference?.message_id;
 }
 
 function mentionsBot(message, botUserId) {

--- a/src/modules/knowledge-base/AskConversationHistory.js
+++ b/src/modules/knowledge-base/AskConversationHistory.js
@@ -1,0 +1,208 @@
+const ASK_HISTORY_FETCH_LIMIT = 100;
+const ASK_HISTORY_MAX_TURNS = 5;
+const ASK_HISTORY_MAX_CHARS = 6000;
+const ASK_RETRIEVAL_HISTORY_MAX_CHARS = 1200;
+const ASK_WARNING_PREFIX = '> -# ⚠️ Snail may be incorrect. This feature is still a work in progress!';
+
+function isSnailAskThreadChannel(channel, botUserId) {
+    return (
+        isThreadChannel(channel) &&
+        Boolean(botUserId && channel?.ownerID === botUserId) &&
+        String(channel?.name ?? '')
+            .toLowerCase()
+            .startsWith('snail ask')
+    );
+}
+
+function buildAskConversationHistory(messages, botUserId, prefixes = []) {
+    const chronological = [...(messages || [])].sort(compareDiscordMessageIds);
+    const askAnswerMessageIds = new Set();
+    const turns = [];
+    let pendingUser = null;
+
+    for (const message of chronological) {
+        if (isBotMessage(message, botUserId)) {
+            if (pendingUser && isSnailAskAnswerMessage(message, botUserId)) {
+                askAnswerMessageIds.add(String(message.id));
+                turns.push({
+                    user: pendingUser,
+                    assistant: cleanAskAnswerContent(message.content),
+                });
+                pendingUser = null;
+            } else if (isSnailAskAnswerMessage(message, botUserId)) {
+                askAnswerMessageIds.add(String(message.id));
+                turns.push({ assistant: cleanAskAnswerContent(message.content) });
+            }
+            continue;
+        }
+
+        if (isAskFlowUserMessage(message, botUserId, askAnswerMessageIds, prefixes)) {
+            pendingUser = cleanUserMessageContent(message.content, botUserId, prefixes);
+        }
+    }
+
+    return capAskHistory(turns);
+}
+
+function formatRetrievalQuery(question, history) {
+    const historyText = formatHistoryForPrompt(history, ASK_RETRIEVAL_HISTORY_MAX_CHARS);
+    if (!historyText) return question;
+    return `Previous ask conversation:\n${historyText}\n\nCurrent user question:\n${question}`;
+}
+
+function capAskHistory(turns) {
+    const recentTurns = turns.slice(-ASK_HISTORY_MAX_TURNS);
+    const capped = [];
+    let chars = 0;
+
+    for (let i = recentTurns.length - 1; i >= 0; i--) {
+        const turn = recentTurns[i];
+        const pair = [
+            { role: 'user', content: turn.user },
+            { role: 'assistant', content: turn.assistant },
+        ].filter((item) => item.content);
+        const pairChars = pair.reduce((total, item) => total + item.content.length, 0);
+        if (capped.length && chars + pairChars > ASK_HISTORY_MAX_CHARS) break;
+        if (!capped.length && pairChars > ASK_HISTORY_MAX_CHARS) {
+            const budget = Math.floor(ASK_HISTORY_MAX_CHARS / pair.length);
+            capped.unshift(...pair.map((item) => ({ ...item, content: truncateForHistory(item.content, budget) })));
+            break;
+        }
+        capped.unshift(...pair);
+        chars += pairChars;
+    }
+
+    return capped;
+}
+
+function formatHistoryForPrompt(history, maxChars) {
+    const lines = [];
+    let chars = 0;
+
+    for (let i = (history || []).length - 1; i >= 0; i--) {
+        const item = history[i];
+        const content = String(item?.content ?? '').trim();
+        if (!content) continue;
+
+        const line = `${item.role === 'assistant' ? 'Snail' : 'User'}: ${content}`;
+        if (lines.length && chars + line.length > maxChars) break;
+        lines.unshift(truncateForHistory(line, maxChars));
+        chars += line.length;
+    }
+
+    return lines.join('\n');
+}
+
+function isAskFlowUserMessage(message, botUserId, askAnswerMessageIds, prefixes) {
+    if (message.author?.bot) return false;
+    if (isAskCommandMessage(message.content, prefixes)) return true;
+    if (mentionsBot(message, botUserId)) return true;
+    return isReplyToSnailAskAnswerMessage(message, botUserId, askAnswerMessageIds);
+}
+
+function isAskCommandMessage(content, prefixes = []) {
+    const text = String(content ?? '')
+        .trim()
+        .toLowerCase();
+    if (/^snail\s+ask(?:\s|$)/.test(text)) return true;
+
+    return (prefixes || [])
+        .map((prefix) =>
+            String(prefix ?? '')
+                .trim()
+                .toLowerCase()
+        )
+        .filter(Boolean)
+        .some((prefix) => {
+            if (!text.startsWith(prefix)) return false;
+            const commandText = text.slice(prefix.length).trimStart();
+            return commandText === 'ask' || commandText.startsWith('ask ');
+        });
+}
+
+function isSnailAskAnswerMessage(message, botUserId) {
+    if (!isBotMessage(message, botUserId)) return false;
+    return String(message.content ?? '').startsWith(ASK_WARNING_PREFIX);
+}
+
+function isThreadChannel(channel) {
+    return Boolean(channel?.threadMetadata || (channel?.parentID && !channel?.createThreadWithMessage));
+}
+
+function isReplyToSnailAskAnswerMessage(message, botUserId, askAnswerMessageIds) {
+    if (!botUserId) return false;
+    const referencedMessageId = message.messageReference?.messageID || message.messageReference?.message_id;
+    if (referencedMessageId && askAnswerMessageIds.has(String(referencedMessageId))) return true;
+    return isSnailAskAnswerMessage(message.referencedMessage, botUserId);
+}
+
+function mentionsBot(message, botUserId) {
+    if (!botUserId) return false;
+    if (message.mentions?.some((user) => user.id === botUserId)) return true;
+    return new RegExp(`<@!?${botUserId}>`).test(String(message.content ?? ''));
+}
+
+function isBotMessage(message, botUserId) {
+    return Boolean(botUserId && message.author?.id === botUserId);
+}
+
+function cleanUserMessageContent(content, botUserId, prefixes) {
+    let text = String(content ?? '')
+        .replace(new RegExp(`<@!?${botUserId}>`, 'g'), '')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+    text = text.replace(/^snail\s+ask\s*/i, '').trim();
+    for (const prefix of prefixes || []) {
+        const normalizedPrefix = String(prefix ?? '').trim();
+        if (!normalizedPrefix) continue;
+        const lowerText = text.toLowerCase();
+        const lowerPrefix = normalizedPrefix.toLowerCase();
+        if (!lowerText.startsWith(lowerPrefix)) continue;
+
+        const commandText = text.slice(normalizedPrefix.length).trimStart();
+        if (commandText.toLowerCase() === 'ask') return '';
+        if (commandText.toLowerCase().startsWith('ask ')) return commandText.slice(3).trimStart();
+    }
+
+    return text;
+}
+
+function cleanAskAnswerContent(content) {
+    return String(content ?? '')
+        .replace(new RegExp(`^${escapeRegExp(ASK_WARNING_PREFIX)}\\s*`, 'i'), '')
+        .replace(/\n\n> -# Tags:.*$/s, '')
+        .trim();
+}
+
+function truncateForHistory(content, maxChars) {
+    const text = String(content ?? '').trim();
+    if (text.length <= maxChars) return text;
+    return `${text.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function compareDiscordMessageIds(a, b) {
+    try {
+        const left = BigInt(a.id);
+        const right = BigInt(b.id);
+        if (left < right) return -1;
+        if (left > right) return 1;
+        return 0;
+    } catch {
+        return String(a.id).localeCompare(String(b.id));
+    }
+}
+
+function escapeRegExp(value) {
+    return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+module.exports = {
+    ASK_HISTORY_FETCH_LIMIT,
+    ASK_WARNING_PREFIX,
+    buildAskConversationHistory,
+    formatRetrievalQuery,
+    isAskCommandMessage,
+    isSnailAskAnswerMessage,
+    isSnailAskThreadChannel,
+};


### PR DESCRIPTION
## Summary
- add OpenRouter Responses API support for Snail ask final answers
- add KB-owned ask conversation history from Snail-created ask threads only
- filter history to eligible ask-flow messages/replies and cap it by turns/chars with no age cap

## Verification
- `node --check src/modules/OpenRouter.js && node --check src/modules/KnowledgeBase.js && node --check src/commands/util/ask.js`
- `npx eslint src/modules/OpenRouter.js src/modules/KnowledgeBase.js src/commands/util/ask.js`
- `npx prettier --check src/modules/OpenRouter.js src/modules/KnowledgeBase.js src/commands/util/ask.js`
- `git diff --check`
- `git diff --check origin/master`
- `npm run lint -- src/modules/OpenRouter.js src/modules/KnowledgeBase.js src/commands/util/ask.js` fails because the repo lint script expands to `npx eslint . ...` and hits pre-existing unrelated errors in untouched files: `src/commands/util/snailRoles.js`, `src/modules/Supporter.js`, `src/user-interaction/GiveItem.js`, and `src/user-interaction/SendUserData.js`.

## Notes
- PDD implement/review passes completed; final re-review approved the first-follow-up history fix.
- No project `test` script exists in package.json.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ask questions in thread replies and receive answers that account for the preceding conversation.
  * Follow-up questions now use relevant prior exchanges for more coherent, context-aware responses.
  * Conversation history is automatically limited to keep responses focused and efficient.
* **Bug Fixes**
  * Improved handling of replies and referenced messages in knowledge-base conversations.
  * Thread-based commands now use the correct channel settings.
  * More consistent answer generation across supported AI response formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->