### PR TITLE
Create Snail ask threads before generating answers

### DIFF
--- a/src/commands/Command.js
+++ b/src/commands/Command.js
@@ -11,6 +11,7 @@ module.exports = class Command {
         this.usage = args.usage;
         this.description = args.description;
         this.examples = args.examples;
+        this.sendTyping = args.sendTyping ?? true;
         this.execute = args.execute;
     }
 };

--- a/src/commands/util/ask.js
+++ b/src/commands/util/ask.js
@@ -13,6 +13,8 @@ module.exports = new Command({
 
     examples: ['snail ask what are gems?', 'snail ask how do I get cowoncy?'],
 
+    sendTyping: false,
+
     execute: async function () {
         const KB = this.bot.modules['knowledgebase'];
 
@@ -38,8 +40,7 @@ module.exports = new Command({
         }
 
         try {
-            const result = await KB.ask(question);
-            await KB.sendAnswer(this.message, result, { question });
+            await KB.answerQuestion(this.message, question);
         } catch (err) {
             console.error('[KB] ask command failed:', err.message);
             await this.error('something went wrong while looking that up.');

--- a/src/modules/CommandHandler.js
+++ b/src/modules/CommandHandler.js
@@ -102,7 +102,7 @@ module.exports = class CommandHandler extends require('./Module') {
             },
         };
 
-        await message.channel.sendTyping();
+        if (command.sendTyping) await message.channel.sendTyping();
 
         if (command.auth(message.member)) {
             // Staff are not bound by the chains of cooldowns >:)

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -166,11 +166,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
         }
 
         await deliveryChannel.sendTyping().catch(() => {});
-        const result = await this.ask(question);
-        await this.sendAnswer(message, result, { question, deliveryChannel });
-    }
-
-    async sendAnswer(message, { answer, sources }, { question, deliveryChannel = message.channel } = {}) {
+        const { answer, sources } = await this.ask(question);
         const collectorModule = this.bot.modules['interactioncollector'];
         const components = this.askFeedbackChannel && collectorModule?.create ? buildAskFeedbackComponents() : [];
         const feedback = {

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -137,11 +137,8 @@ module.exports = class KnowledgeBase extends require('./Module') {
         if (!stripped) return;
         if (stripped.length > 500) return;
 
-        await message.channel.sendTyping().catch(() => {});
-
         try {
-            const result = await this.ask(stripped);
-            await this.sendAnswer(message, result, { question: stripped });
+            await this.answerQuestion(message, stripped);
         } catch (err) {
             console.error('[KB] mention ask failed:', err.message);
             await message.channel
@@ -154,7 +151,26 @@ module.exports = class KnowledgeBase extends require('./Module') {
         }
     }
 
-    async sendAnswer(message, { answer, sources }, { question } = {}) {
+    async answerQuestion(message, question) {
+        let deliveryChannel = message.channel;
+
+        if (!isThreadChannel(deliveryChannel) && typeof deliveryChannel?.createThreadWithMessage === 'function') {
+            try {
+                deliveryChannel = await deliveryChannel.createThreadWithMessage(message.id, {
+                    name: buildAskThreadName(question),
+                    autoArchiveDuration: 1440,
+                });
+            } catch (err) {
+                console.warn('[KB] ask thread creation failed, falling back to reply:', err.message);
+            }
+        }
+
+        await deliveryChannel.sendTyping().catch(() => {});
+        const result = await this.ask(question);
+        await this.sendAnswer(message, result, { question, deliveryChannel });
+    }
+
+    async sendAnswer(message, { answer, sources }, { question, deliveryChannel = message.channel } = {}) {
         const collectorModule = this.bot.modules['interactioncollector'];
         const components = this.askFeedbackChannel && collectorModule?.create ? buildAskFeedbackComponents() : [];
         const feedback = {
@@ -164,39 +180,29 @@ module.exports = class KnowledgeBase extends require('./Module') {
             sources,
         };
 
-        const threadAnswer = await this.trySendThreadAnswer(message, answer, sources, components, question);
-        if (threadAnswer) {
-            if (this.askFeedbackChannel && collectorModule?.create) {
-                this.collectAskFeedback(collectorModule, threadAnswer.answerMessage, threadAnswer.content, feedback);
-            }
-            return;
-        }
-
-        const content = this.buildFallbackAnswerContent(answer, sources, components, message);
-        const answerMessage = await message.channel.createMessage(content);
-
-        if (this.askFeedbackChannel && collectorModule?.create) {
-            this.collectAskFeedback(collectorModule, answerMessage, content, feedback);
-        }
-    }
-
-    async trySendThreadAnswer(message, answer, sources, components, question) {
-        if (typeof message.channel?.createThreadWithMessage !== 'function') return;
-
-        try {
-            const thread = await message.channel.createThreadWithMessage(message.id, {
-                name: buildAskThreadName(question),
-                autoArchiveDuration: 1440,
-            });
-            const content = {
+        let content;
+        if (deliveryChannel === message.channel) {
+            content = this.buildFallbackAnswerContent(answer, sources, components, message);
+        } else {
+            content = {
                 content: buildPlainAnswerContent(answer, sources),
                 components,
                 allowedMentions: { repliedUser: false, everyone: false, roles: false, users: false },
             };
-            const answerMessage = await thread.createMessage(content);
-            return { answerMessage, content };
+        }
+
+        let answerMessage;
+        try {
+            answerMessage = await deliveryChannel.createMessage(content);
         } catch (err) {
-            console.warn('[KB] ask thread delivery failed, falling back to reply:', err.message);
+            if (deliveryChannel === message.channel) throw err;
+            console.warn('[KB] ask thread answer failed, falling back to reply:', err.message);
+            content = this.buildFallbackAnswerContent(answer, sources, components, message);
+            answerMessage = await message.channel.createMessage(content);
+        }
+
+        if (this.askFeedbackChannel && collectorModule?.create) {
+            this.collectAskFeedback(collectorModule, answerMessage, content, feedback);
         }
     }
 
@@ -349,7 +355,8 @@ module.exports = class KnowledgeBase extends require('./Module') {
         const sources = selectAnswerSources(groups, answerResponse);
 
         return {
-            answer: answerResponse.answer || "I don't know that one yet — please ask a helper or rephrase your question.",
+            answer:
+                answerResponse.answer || "I don't know that one yet — please ask a helper or rephrase your question.",
             sources,
             hits,
         };
@@ -1428,7 +1435,7 @@ function isThreadChannel(channel) {
 }
 
 function buildPlainAnswerContent(answer, sources) {
-    let content = `> -# ⚠️ Snail may be incorrect. This feature is still a work in progress!\n\n`
+    let content = `> -# ⚠️ Snail may be incorrect. This feature is still a work in progress!\n\n`;
     content += String(answer ?? '');
     const publicSources = (sources ?? []).filter((source) => source?.visibility !== 'kb_only');
 


### PR DESCRIPTION
## Summary
- create Snail ask threads before starting answer generation
- send typing notifications in the created/existing answer thread
- route mention asks and `snail ask` through the same KnowledgeBase-owned flow
- suppress the generic parent-channel typing notification for `snail ask`
- preserve same-channel and thread-post failure fallbacks plus feedback handling

## Verification
- `node /tmp/snail-ask-thread-harness.js`
- `node --check` on all four changed JavaScript files
- focused ESLint on all four changed files
- focused Prettier check on all four changed files
- `git diff --check origin/master...HEAD`

## Baseline note
- Full `npm run lint` still reports 13 unrelated pre-existing errors in `snailRoles.js`, `Supporter.js`, `GiveItem.js`, and `SendUserData.js`; all changed files pass focused ESLint.
