### PR TITLE
feat(kb): configure ask thread responses

### DIFF
--- a/src/commands/modules/kb.js
+++ b/src/commands/modules/kb.js
@@ -38,6 +38,7 @@ module.exports = new Command({
         '- `snail kb exclude {tag...}`\n  - Exclude one or more tags from KB retrieval and delete their Qdrant points\n' +
         '- `snail kb include {tag...}`\n  - Include one or more tags in KB retrieval and sync their Qdrant points\n' +
         '- `snail kb excluded`\n  - List tags excluded from KB retrieval\n' +
+        '- `snail kb enableThreads true|false`\n  - Enable or disable ask thread responses\n' +
         '- `snail kb model {modelSlug}`\n  - Set the chat model (OpenRouter slug)\n',
 
     examples: [
@@ -58,6 +59,7 @@ module.exports = new Command({
         'snail kb exclude newtr trstart',
         'snail kb include newtr trstart',
         'snail kb excluded',
+        'snail kb enableThreads false',
         'snail kb model anthropic/claude-haiku-4.5',
     ],
 
@@ -103,11 +105,21 @@ module.exports = new Command({
                 return setTagExcluded.call(this, KB, false);
             case 'excluded':
                 return listExcludedTags.call(this, KB);
+            case 'enablethreads': {
+                const [value] = this.message.args;
+                if (this.message.args.length !== 1 || (value !== 'true' && value !== 'false')) {
+                    await this.error('please choose exactly `true` or `false`.');
+                    return;
+                }
+                const enabled = value === 'true';
+                await KB.setThreadsEnabled(enabled);
+                return this.send(`I have set KB thread responses to \`${enabled}\`!`);
+            }
             case 'model':
                 return setModel.call(this, openrouter);
             default:
                 await this.error(
-                    'that is not a valid subcommand! Use `snail kb [status|reindex|reset|find|add|edit|delete|list|questions|term|exclude|include|excluded|model] {...arguments}`'
+                    'that is not a valid subcommand! Use `snail kb [status|reindex|reset|find|add|edit|delete|list|questions|term|exclude|include|excluded|enableThreads|model] {...arguments}`'
                 );
         }
     },
@@ -190,7 +202,9 @@ async function runReindex(KB) {
     const regenerateQuestions = modes.has('questions');
 
     if (dry && regenerateQuestions) {
-        await this.error('`snail kb reindex questions` regenerates Mongo question caches, so it cannot be combined with `dry`.');
+        await this.error(
+            '`snail kb reindex questions` regenerates Mongo question caches, so it cannot be combined with `dry`.'
+        );
         return;
     }
 

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -106,12 +106,13 @@ module.exports = class KnowledgeBase extends require('./Module') {
     }
 
     async onceReady() {
+        const persistedThreadsEnabled = await this.bot.getConfiguration(`${this.id}_threads_enabled`);
+        if (typeof persistedThreadsEnabled === 'boolean') this.threadsEnabled = persistedThreadsEnabled;
+
         await super.onceReady();
 
         const persistedFeedbackChannel = await this.bot.getConfiguration(`${this.id}_ask_feedback_channel`);
         if (persistedFeedbackChannel) this.askFeedbackChannel = persistedFeedbackChannel;
-        const persistedThreadsEnabled = await this.bot.getConfiguration(`${this.id}_threads_enabled`);
-        if (typeof persistedThreadsEnabled === 'boolean') this.threadsEnabled = persistedThreadsEnabled;
         await this.openrouter.loadPersistedConfiguration();
 
         if (this.enabled) {
@@ -135,7 +136,6 @@ module.exports = class KnowledgeBase extends require('./Module') {
     }
 
     async setThreadsEnabled(enabled) {
-        if (typeof enabled !== 'boolean') throw new TypeError('Threads enabled must be a boolean');
         await this.bot.setConfiguration(`${this.id}_threads_enabled`, enabled);
         this.threadsEnabled = enabled;
     }

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -73,6 +73,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
         this.scoreThreshold = kbConfig.scoreThreshold ?? 0.3;
         this.dupeThreshold = kbConfig.dupeThreshold ?? 0.75;
         this.askFeedbackChannel = kbConfig.askFeedbackChannel;
+        this.threadsEnabled = true;
 
         this.qdrant = null;
         this.syncing = false;
@@ -109,6 +110,8 @@ module.exports = class KnowledgeBase extends require('./Module') {
 
         const persistedFeedbackChannel = await this.bot.getConfiguration(`${this.id}_ask_feedback_channel`);
         if (persistedFeedbackChannel) this.askFeedbackChannel = persistedFeedbackChannel;
+        const persistedThreadsEnabled = await this.bot.getConfiguration(`${this.id}_threads_enabled`);
+        if (typeof persistedThreadsEnabled === 'boolean') this.threadsEnabled = persistedThreadsEnabled;
         await this.openrouter.loadPersistedConfiguration();
 
         if (this.enabled) {
@@ -129,6 +132,12 @@ module.exports = class KnowledgeBase extends require('./Module') {
         } catch (err) {
             console.error('[KB] enable failed:', err.message);
         }
+    }
+
+    async setThreadsEnabled(enabled) {
+        if (typeof enabled !== 'boolean') throw new TypeError('Threads enabled must be a boolean');
+        await this.bot.setConfiguration(`${this.id}_threads_enabled`, enabled);
+        this.threadsEnabled = enabled;
     }
 
     async initQdrant() {
@@ -174,7 +183,11 @@ module.exports = class KnowledgeBase extends require('./Module') {
     async answerQuestion(message, question) {
         let deliveryChannel = message.channel;
 
-        if (!isThreadChannel(deliveryChannel) && typeof deliveryChannel?.createThreadWithMessage === 'function') {
+        if (
+            this.threadsEnabled &&
+            !isThreadChannel(deliveryChannel) &&
+            typeof deliveryChannel?.createThreadWithMessage === 'function'
+        ) {
             try {
                 deliveryChannel = await deliveryChannel.createThreadWithMessage(message.id, {
                     name: buildAskThreadName(question),


### PR DESCRIPTION
## Summary
- add `snail kb enableThreads true|false` for manager-controlled KB answer delivery
- persist the KnowledgeBase-owned setting with a default of thread responses enabled
- reuse the existing same-channel reply fallback when thread responses are disabled

## Behavior
- `true`: non-thread questions create an ask thread before answer generation, preserving current behavior
- `false`: non-thread questions receive the existing same-channel reply response
- questions already inside threads continue replying in-thread without nested threads
- missing, invalid, or extra setting values are rejected without changing the setting

## Verification
- temporary RED/GREEN behavior harness: default/load/persist, strict command validation, enabled/disabled delivery, existing-thread delivery
- startup-race harness: persisted `false` is applied before message handling is enabled
- parent behavior and startup-race harnesses: PASS
- `node --check src/modules/KnowledgeBase.js`
- `node --check src/commands/modules/kb.js`
- `npx eslint src/modules/KnowledgeBase.js src/commands/modules/kb.js`
- `npx prettier --check src/modules/KnowledgeBase.js src/commands/modules/kb.js`
- `git diff --check`
- separate phase review: APPROVE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to enable or disable Knowledge Base response threads.
  * Added the `kb enableThreads true|false` command to update and confirm the setting.
  * The thread setting is saved and restored automatically, and threads are enabled by default.

* **Documentation**
  * Updated command usage, examples, and help text for the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->