### PR TITLE
fix(kb): address thread setting review

### DIFF
--- a/src/commands/modules/kb.js
+++ b/src/commands/modules/kb.js
@@ -106,7 +106,7 @@ module.exports = new Command({
             case 'excluded':
                 return listExcludedTags.call(this, KB);
             case 'enablethreads': {
-                const [value] = this.message.args;
+                const value = this.message.args[0]?.toLowerCase();
                 if (this.message.args.length !== 1 || (value !== 'true' && value !== 'false')) {
                     await this.error('please choose exactly `true` or `false`.');
                     return;
@@ -155,6 +155,7 @@ async function showStatus(KB, openrouter) {
         color: this.config.embedcolor,
         description:
             `**Enabled:** ${KB.enabled}\n` +
+            `**Thread Responses:** ${KB.threadsEnabled}\n` +
             `**Collection:** \`${KB.collection}\`\n` +
             `**Points in Qdrant:** ${pointCount}\n` +
             `**Chat Model:** \`${openrouter.chatModel}\`\n` +

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -136,6 +136,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
     }
 
     async setThreadsEnabled(enabled) {
+        if (typeof enabled !== 'boolean') throw new TypeError('enabled must be a boolean.');
         await this.bot.setConfiguration(`${this.id}_threads_enabled`, enabled);
         this.threadsEnabled = enabled;
     }


### PR DESCRIPTION
## Summary
- accept case-insensitive `true|false` values for `snail kb enableThreads`
- show the effective thread-response setting in `snail kb status`
- reject non-boolean values at the `KnowledgeBase` owner boundary before persistence

## PR #52 review follow-up
- addresses Copilot's command-normalization and status-visibility comments
- addresses CodeRabbit's setter-invariant comment
- no additional listener gate is needed: `Module.addEvent` skips handlers while the module is disabled, and `KnowledgeBase.onceReady` restores the persisted thread setting before `super.onceReady()` enables message handling

## Verification
- temporary RED/GREEN behavior harness: owner invariant, case-insensitive command values, and status visibility
- parent behavior harness: PASS
- `node --check src/modules/KnowledgeBase.js`
- `node --check src/commands/modules/kb.js`
- `npx eslint src/modules/KnowledgeBase.js src/commands/modules/kb.js`
- `npx prettier --check src/modules/KnowledgeBase.js src/commands/modules/kb.js`
- `git diff --check`

## Baseline notes
- full-repository ESLint still reports 13 unchanged errors in unrelated files
- full-repository Prettier still cannot parse the existing newline-delimited `tags.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KB status information now shows whether thread responses are enabled.
  * The `enablethreads` setting accepts case-insensitive boolean values.

* **Bug Fixes**
  * Invalid thread-response settings are rejected before being saved or applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->