### PR TITLE
Fallback when KB thread creation is rate limited

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "bad-words": "^3.0.3",
         "dotenv": "^8.2.0",
         "elastic-apm-node": "^4.18.0",
-        "eris": "^0.18.0",
+        "eris": "git+https://github.com/ChristopherBThai/eris.git#dd03e34058f4382d572c410a6ab599859b34e2fc",
         "eventemitter3": "^5.0.1",
         "got": "^11.8.0",
         "mongoose": "^9.8.0",
@@ -944,8 +944,9 @@
     },
     "node_modules/eris": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/eris/-/eris-0.18.0.tgz",
-      "integrity": "sha512-zv2hjAfs4SYjR/EHUwBGNoKClctbqki1jPMed4SiQ4KKfafV1MIBLqKodQSGDgT9qkSUI5+MQ4EQW/8MkbAPkg==",
+      "resolved": "git+ssh://git@github.com/ChristopherBThai/eris.git#dd03e34058f4382d572c410a6ab599859b34e2fc",
+      "integrity": "sha512-tk++CAe1ubG/O4HAj08NNwwNE1vn3CfVWPTILuISf/98U1MR+4j3vmVNUgcY+3vIGxGABVSlEofHoiLwLL37Kg==",
+      "license": "MIT",
       "dependencies": {
         "ws": "^8.2.3"
       },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "bad-words": "^3.0.3",
     "dotenv": "^8.2.0",
     "elastic-apm-node": "^4.18.0",
-    "eris": "^0.18.0",
+    "eris": "git+https://github.com/ChristopherBThai/eris.git#dd03e34058f4382d572c410a6ab599859b34e2fc",
     "eventemitter3": "^5.0.1",
     "got": "^11.8.0",
     "mongoose": "^9.8.0",

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const Eris = require('eris');
 const { v5: uuidv5 } = require('uuid');
 
 const { ephemeralInteractionResponse } = require('../utils/sender.js');
@@ -190,10 +191,17 @@ module.exports = class KnowledgeBase extends require('./Module') {
             typeof deliveryChannel?.createThreadWithMessage === 'function'
         ) {
             try {
-                deliveryChannel = await deliveryChannel.createThreadWithMessage(message.id, {
-                    name: buildAskThreadName(question),
-                    autoArchiveDuration: 60,
-                });
+                const rawChannel = await this.bot.requestHandler.request(
+                    'POST',
+                    `/channels/${message.channel.id}/messages/${message.id}/threads`,
+                    true,
+                    {
+                        auto_archive_duration: 60,
+                        name: buildAskThreadName(question),
+                        rejectOn429: true,
+                    }
+                );
+                deliveryChannel = Eris.Channel.from(rawChannel, this.bot);
             } catch (err) {
                 console.warn('[KB] ask thread creation failed, falling back to reply:', err.message);
             }


### PR DESCRIPTION
## Summary

- pin Snail to the merged Eris fork commit that supports request-scoped 429 rejection
- create KB answer threads through Eris's RequestHandler with `rejectOn429: true`
- convert successful raw thread responses with `Eris.Channel.from`
- let rejected thread creation use Snail's existing same-channel reply fallback

## Scope

- no cooldown or future-request suppression
- no rate-limit parsing in Snail
- no high-level Eris adapter changes

## Verification

- disposable behavioral harness: exact REST route/body, rejected creation reply fallback, successful channel conversion and thread delivery
- `npm ci` and installed-Eris feature probe
- `node --check src/modules/KnowledgeBase.js`
- focused ESLint and Prettier checks on touched files
- package JSON parsing
- `git diff --check`
- focused PDD phase review: approved
- final broad review: approved
- final ponytail review: `Lean already. Ship.`

## Baseline checks

- full `npm run lint` reports 13 pre-existing errors in untouched files
- full `npm run prettier` cannot parse the unchanged multi-document `tags.json`; all touched files pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread creation reliability when responding to messages.
  * Ensured newly created threads are handled correctly for continued interactions.
  * Added a fallback that replies in the original channel if thread creation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->