### PR TITLE
feat(kb): display private tags

### DIFF
--- a/src/commands/modules/kb.js
+++ b/src/commands/modules/kb.js
@@ -27,6 +27,7 @@ module.exports = new Command({
         '- `snail kb reindex questions`\n  - Regenerate retrieval questions for all tags, then incrementally sync Qdrant\n' +
         '- `snail kb reset confirm`\n  - Destructively recreate the Qdrant collection, then sync Mongo tags. Remote resets require backup through `ssh hub.corg.network` first.\n' +
         '- `snail kb find {query}`\n  - Search matching tags for manager/debug review\n' +
+        '- `snail kb tag {tag}`\n  - Display a KB-only/private support tag\n' +
         '- `snail kb add {name} {data}`\n  - Add a KB-only/private support tag\n' +
         '- `snail kb edit {name} {data}`\n  - Edit a KB-only/private support tag\n' +
         '- `snail kb delete {name}`\n  - Delete a KB-only/private support tag\n' +
@@ -48,6 +49,7 @@ module.exports = new Command({
         'snail kb reindex questions',
         'snail kb reset confirm',
         'snail kb find how do gems expire',
+        'snail kb tag privategems',
         'snail kb add privategems Private note for support helpers only',
         'snail kb edit privategems Updated private note for support helpers only',
         'snail kb delete privategems',
@@ -87,6 +89,8 @@ module.exports = new Command({
                 return runReset.call(this, KB);
             case 'find':
                 return runFind.call(this, KB);
+            case 'tag':
+                return showKbOnlyTag.call(this);
             case 'add':
                 return addKbOnlyTag.call(this, KB);
             case 'edit':
@@ -119,7 +123,7 @@ module.exports = new Command({
                 return setModel.call(this, openrouter);
             default:
                 await this.error(
-                    'that is not a valid subcommand! Use `snail kb [status|reindex|reset|find|add|edit|delete|list|questions|term|exclude|include|excluded|enableThreads|model] {...arguments}`'
+                    'that is not a valid subcommand! Use `snail kb [status|reindex|reset|find|tag|add|edit|delete|list|questions|term|exclude|include|excluded|enableThreads|model] {...arguments}`'
                 );
         }
     },
@@ -340,6 +344,22 @@ async function runFind(KB) {
             fields,
         },
     });
+}
+
+async function showKbOnlyTag() {
+    const name = this.message.args.shift()?.toLowerCase();
+    if (!name || this.message.args.length) {
+        await this.error('please provide exactly one tag name!');
+        return;
+    }
+
+    const tag = await this.snail_db.Tag.findOne({ _id: name, visibility: 'kb_only' });
+    if (!tag) {
+        await this.error('that tag does not exist!');
+        return;
+    }
+
+    await this.send(tag.data);
 }
 
 async function addKbOnlyTag(KB) {


### PR DESCRIPTION
## Summary
- add `snail kb tag <tag>` to display KB-only/private tags
- restrict lookup to tags with `visibility: 'kb_only'`
- render authoritative tag data with the same plain response used by `snail tag <tag>`
- document the new subcommand in KB help and examples

## Verification
- temporary external behavior harness covering private, public, missing, omitted, extra, and case-normalized tag IDs
- `node -c src/commands/modules/kb.js`
- `npx eslint --quiet src/commands/modules/kb.js`
- `npx prettier --check src/commands/modules/kb.js`
- `git diff --check`
- independent phase review: approved
- final broad architecture review: approved
- final ponytail review: approved (`Lean already. Ship.`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to display details for a single knowledge-base-only tag.
  * Added validation and clear feedback for missing or invalid tag names.
  * Updated command examples and help text to include the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->