### PR TITLE
fix(kb): parse markdown escapes in answer JSON

### DIFF
--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -1167,11 +1167,23 @@ function unwrapJsonResponse(content) {
 
 function parseAnswerResponse(content) {
     const rawAnswer = String(content ?? '').trim();
+    const jsonResponse = unwrapJsonResponse(content);
     let parsed;
     try {
-        parsed = JSON.parse(unwrapJsonResponse(content));
+        parsed = JSON.parse(jsonResponse);
     } catch (err) {
-        return { answer: rawAnswer, tagIds: [], parseFailed: true };
+        try {
+            parsed = JSON.parse(
+                jsonResponse.replace(/"(?:\\.|[^"\\])*"/g, (jsonString) =>
+                    jsonString.replace(
+                        /\\(?:["\\/bfnrt]|u[0-9a-fA-F]{4})|\\([!#$%&'()*+,\-.:;<=>?@[\]^_`{|}~])/g,
+                        (match, markdownPunctuation) => markdownPunctuation ?? match
+                    )
+                )
+            );
+        } catch (recoveryErr) {
+            return { answer: rawAnswer, tagIds: [], parseFailed: true };
+        }
     }
 
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed) || typeof parsed.answer !== 'string') {


### PR DESCRIPTION
## Summary
- retry structured Snail answer parsing after repairing invalid Markdown punctuation escapes inside JSON strings
- preserve valid JSON escapes atomically during recovery
- keep prompt text and existing malformed/schema-invalid fallback behavior unchanged

## Verification
- real `fetchAskAnswer` harness: exact `\- or -`, cited source retention, mixed escaped-backslash parity, all standard JSON escapes, malformed/non-Markdown fallback controls
- `npx prettier --check src/modules/KnowledgeBase.js`
- `npx eslint src/modules/KnowledgeBase.js`
- `node --check src/modules/KnowledgeBase.js`
- `git diff --check origin/master...HEAD`
- PDD phase review, final broad review, and ponytail review approved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of knowledge base responses with wrapped or improperly escaped JSON.
  * Preserves the original answer when parsing cannot be completed, preventing data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->