### PR TITLE
fix(kb): ignore replies outside Snail-owned threads

### DIFF
--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -152,12 +152,13 @@ module.exports = class KnowledgeBase extends require('./Module') {
 
     async onMessage(message) {
         if (message.author?.bot) return;
+        const mentioned = message.mentions?.some((u) => u.id === this.bot.user?.id);
         if (
             message.type === Eris.Constants.MessageTypes.REPLY &&
+            !mentioned &&
             !isSnailAskThreadChannel(message.channel, this.bot.user?.id)
         )
             return;
-        const mentioned = message.mentions?.some((u) => u.id === this.bot.user?.id);
         if (!mentioned && isAskCommandMessage(message.content, this.askCommandPrefixes)) return;
 
         const askThreadReply = mentioned ? false : await this.isAskThreadReplyMessage(message);

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -12,6 +12,7 @@ const {
     isAskCommandMessage,
     isSnailAskAnswerMessage,
     isSnailAskThreadChannel,
+    isThreadChannel,
 } = require('./knowledge-base/AskConversationHistory.js');
 
 const SYSTEM_PROMPT =
@@ -151,6 +152,11 @@ module.exports = class KnowledgeBase extends require('./Module') {
 
     async onMessage(message) {
         if (message.author?.bot) return;
+        if (
+            message.type === Eris.Constants.MessageTypes.REPLY &&
+            !isSnailAskThreadChannel(message.channel, this.bot.user?.id)
+        )
+            return;
         const mentioned = message.mentions?.some((u) => u.id === this.bot.user?.id);
         if (!mentioned && isAskCommandMessage(message.content, this.askCommandPrefixes)) return;
 
@@ -1544,10 +1550,6 @@ function normalizedTagData(group) {
         .replace(/[ \t]+\n/g, '\n')
         .replace(/\n{3,}/g, '\n\n')
         .trim();
-}
-
-function isThreadChannel(channel) {
-    return Boolean(channel?.threadMetadata || (channel?.parentID && !channel?.createThreadWithMessage));
 }
 
 function buildPlainAnswerContent(answer, sources) {

--- a/src/modules/knowledge-base/AskConversationHistory.js
+++ b/src/modules/knowledge-base/AskConversationHistory.js
@@ -1,3 +1,5 @@
+const Eris = require('eris');
+
 const ASK_HISTORY_FETCH_LIMIT = 100;
 const ASK_HISTORY_MAX_TURNS = 5;
 const ASK_HISTORY_MAX_CHARS = 6000;
@@ -5,13 +7,7 @@ const ASK_RETRIEVAL_HISTORY_MAX_CHARS = 1200;
 const ASK_WARNING_PREFIX = '> -# ⚠️ Snail may be incorrect. This feature is still a work in progress!';
 
 function isSnailAskThreadChannel(channel, botUserId) {
-    return (
-        isThreadChannel(channel) &&
-        Boolean(botUserId && channel?.ownerID === botUserId) &&
-        String(channel?.name ?? '')
-            .toLowerCase()
-            .startsWith('snail ask')
-    );
+    return isThreadChannel(channel) && Boolean(botUserId && channel?.ownerID === botUserId);
 }
 
 function buildAskConversationHistory(messages, botUserId, prefixes = []) {
@@ -133,7 +129,11 @@ function isSnailAskAnswerMessage(message, botUserId) {
 }
 
 function isThreadChannel(channel) {
-    return Boolean(channel?.threadMetadata || (channel?.parentID && !channel?.createThreadWithMessage));
+    return [
+        Eris.Constants.ChannelTypes.GUILD_NEWS_THREAD,
+        Eris.Constants.ChannelTypes.GUILD_PUBLIC_THREAD,
+        Eris.Constants.ChannelTypes.GUILD_PRIVATE_THREAD,
+    ].includes(channel?.type);
 }
 
 function isReplyToSnailAskAnswerMessage(message, botUserId, askAnswerMessageIds) {
@@ -216,4 +216,5 @@ module.exports = {
     isAskCommandMessage,
     isSnailAskAnswerMessage,
     isSnailAskThreadChannel,
+    isThreadChannel,
 };


### PR DESCRIPTION
## Summary

- ignore Knowledge Base `REPLY` message activation outside Snail-owned threads
- classify threads from Eris channel types instead of inferred channel fields
- identify Snail ask threads by thread type and owner ID only, without title matching
- share the Knowledge Base thread classifier between routing, delivery, and history handling

## Verification

- `node /tmp/snail-kb-reply-thread-gate-parent-harness.js`
- `npx eslint src/modules/KnowledgeBase.js src/modules/knowledge-base/AskConversationHistory.js`
- `npx prettier --check src/modules/KnowledgeBase.js src/modules/knowledge-base/AskConversationHistory.js`
- `node --check src/modules/KnowledgeBase.js`
- `node --check src/modules/knowledge-base/AskConversationHistory.js`
- `git diff --check origin/master...HEAD`

## Scope

Only `src/modules/KnowledgeBase.js` and `src/modules/knowledge-base/AskConversationHistory.js` are changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message handling so Discord replies outside Snail Ask threads are ignored.
  * Snail Ask conversations are now recognized based on their thread type and bot ownership, rather than requiring a specific thread name prefix.
  * Improved consistency in identifying eligible Snail Ask threads across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->