### PR TITLE
refactor(kb): consolidate ask answer protocol

### DIFF
--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -6,14 +6,17 @@ const { ephemeralInteractionResponse } = require('../utils/sender.js');
 const { Qdrant } = require('../utils/kb.js');
 const {
     ASK_HISTORY_FETCH_LIMIT,
-    ASK_WARNING_PREFIX,
+    buildAskAnswerContent,
     buildAskConversationHistory,
+    buildAskFeedbackComponents,
+    disableAskFeedbackComponents,
     formatRetrievalQuery,
+    getAskFeedbackRating,
     isAskCommandMessage,
     isSnailAskAnswerMessage,
     isSnailAskThreadChannel,
     isThreadChannel,
-} = require('./knowledge-base/AskConversationHistory.js');
+} = require('./knowledge-base/AskConversation.js');
 
 const SYSTEM_PROMPT =
     'You are Snail, a friendly helper in the OwO Discord bot support server. ' +
@@ -38,8 +41,6 @@ const ASK_QDRANT_RETRY_ATTEMPTS = 2;
 const ASK_RETRY_DELAY_MS = 500;
 const DEFAULT_RERANK_CANDIDATE_LIMIT = 30;
 const ASK_FEEDBACK_IDLE_MS = 30 * 60 * 1000;
-const ASK_FEEDBACK_HELPFUL_ID = 'kb_ask_feedback_helpful';
-const ASK_FEEDBACK_NEEDS_FIX_ID = 'kb_ask_feedback_needs_fix';
 const EMBED_FIELD_VALUE_LIMIT = 1024;
 const TAG_SYNC_LOG_EVERY = 25;
 const RAW_GENERATION_RESPONSE_LOG_CHARS = 4000;
@@ -110,11 +111,11 @@ module.exports = class KnowledgeBase extends require('./Module') {
     async onceReady() {
         const persistedThreadsEnabled = await this.bot.getConfiguration(`${this.id}_threads_enabled`);
         if (typeof persistedThreadsEnabled === 'boolean') this.threadsEnabled = persistedThreadsEnabled;
+        const persistedFeedbackChannel = await this.bot.getConfiguration(`${this.id}_ask_feedback_channel`);
+        if (persistedFeedbackChannel) this.askFeedbackChannel = persistedFeedbackChannel;
 
         await super.onceReady();
 
-        const persistedFeedbackChannel = await this.bot.getConfiguration(`${this.id}_ask_feedback_channel`);
-        if (persistedFeedbackChannel) this.askFeedbackChannel = persistedFeedbackChannel;
         await this.openrouter.loadPersistedConfiguration();
 
         if (this.enabled) {
@@ -217,7 +218,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
         await deliveryChannel.sendTyping().catch(() => {});
         const { answer, sources } = await this.ask(question, { message });
         const collectorModule = this.bot.modules['interactioncollector'];
-        const components = this.askFeedbackChannel && collectorModule?.create ? buildAskFeedbackComponents() : [];
+        const components = buildAskFeedbackComponents();
         const feedback = {
             originalMessage: message,
             question,
@@ -230,7 +231,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
             content = this.buildFallbackAnswerContent(answer, sources, components, message);
         } else {
             content = {
-                content: buildPlainAnswerContent(answer, sources),
+                content: buildAskAnswerContent(answer, sources),
                 components,
                 allowedMentions: { repliedUser: false, everyone: false, roles: false, users: false },
             };
@@ -246,7 +247,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
             answerMessage = await message.channel.createMessage(content);
         }
 
-        if (this.askFeedbackChannel && collectorModule?.create) {
+        if (collectorModule?.create) {
             this.collectAskFeedback(collectorModule, answerMessage, content, feedback);
         }
     }
@@ -261,7 +262,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
         if (isThreadChannel(message.channel)) {
             return {
                 ...base,
-                content: buildPlainAnswerContent(answer, sources),
+                content: buildAskAnswerContent(answer, sources),
             };
         }
 
@@ -270,7 +271,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
             embeds: [
                 {
                     color: this.bot.config.embedcolor,
-                    description: buildPlainAnswerContent(answer, sources),
+                    description: buildAskAnswerContent(answer, sources),
                 },
             ],
         };
@@ -286,7 +287,9 @@ module.exports = class KnowledgeBase extends require('./Module') {
             if (!rating) return;
 
             try {
-                await this.forwardAskFeedback(answerMessage, feedback, rating);
+                if (this.askFeedbackChannel) {
+                    await this.forwardAskFeedback(answerMessage, feedback, rating);
+                }
                 submitted = true;
                 content.components = buildAskFeedbackComponents(rating.id);
                 await answerMessage.edit(content).catch(() => {});
@@ -302,7 +305,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
 
         collector.on('end', async () => {
             if (submitted) return;
-            content.components = disableComponents(content.components);
+            content.components = disableAskFeedbackComponents(content.components);
             await answerMessage.edit(content).catch(() => {});
         });
     }
@@ -1460,46 +1463,6 @@ async function leanQuery(query) {
     return query;
 }
 
-function buildAskFeedbackComponents(selectedId) {
-    return [
-        {
-            type: 1,
-            components: [
-                {
-                    type: 2,
-                    custom_id: ASK_FEEDBACK_HELPFUL_ID,
-                    style: selectedId === ASK_FEEDBACK_HELPFUL_ID ? 3 : 2,
-                    label: selectedId === ASK_FEEDBACK_HELPFUL_ID ? 'Helpful ✓' : 'Helpful',
-                    disabled: Boolean(selectedId),
-                },
-                {
-                    type: 2,
-                    custom_id: ASK_FEEDBACK_NEEDS_FIX_ID,
-                    style: selectedId === ASK_FEEDBACK_NEEDS_FIX_ID ? 4 : 2,
-                    label: selectedId === ASK_FEEDBACK_NEEDS_FIX_ID ? 'Needs Fix ✓' : 'Needs Fix',
-                    disabled: Boolean(selectedId),
-                },
-            ],
-        },
-    ];
-}
-
-function getAskFeedbackRating(customId) {
-    switch (customId) {
-        case ASK_FEEDBACK_HELPFUL_ID:
-            return { id: ASK_FEEDBACK_HELPFUL_ID, label: 'Helpful', color: 10412190 };
-        case ASK_FEEDBACK_NEEDS_FIX_ID:
-            return { id: ASK_FEEDBACK_NEEDS_FIX_ID, label: 'Needs Fix', color: 16737891 };
-    }
-}
-
-function disableComponents(components) {
-    return components.map((row) => ({
-        ...row,
-        components: row.components.map((component) => ({ ...component, disabled: true })),
-    }));
-}
-
 function buildDiscordMessageLink(message) {
     const guildId = message.guildID || message.channel?.guild?.id;
     if (!guildId || !message.channel?.id || !message.id) return;
@@ -1551,15 +1514,6 @@ function normalizedTagData(group) {
         .replace(/[ \t]+\n/g, '\n')
         .replace(/\n{3,}/g, '\n\n')
         .trim();
-}
-
-function buildPlainAnswerContent(answer, sources) {
-    let content = `${ASK_WARNING_PREFIX}\n\n`;
-    content += String(answer ?? '');
-    const publicSources = (sources ?? []).filter((source) => source?.visibility !== 'kb_only');
-
-    if (!publicSources.length) return content;
-    return `${content}\n\n> -# Tags: ${publicSources.slice(0, 5).map(formatSource).join(', ')}`;
 }
 
 function buildAskThreadName(question) {

--- a/src/modules/knowledge-base/AskConversation.js
+++ b/src/modules/knowledge-base/AskConversation.js
@@ -5,6 +5,69 @@ const ASK_HISTORY_MAX_TURNS = 5;
 const ASK_HISTORY_MAX_CHARS = 6000;
 const ASK_RETRIEVAL_HISTORY_MAX_CHARS = 1200;
 const ASK_WARNING_PREFIX = '> -# ⚠️ Snail may be incorrect. This feature is still a work in progress!';
+const ASK_FEEDBACK_HELPFUL_ID = 'kb_ask_feedback_helpful';
+const ASK_FEEDBACK_NEEDS_FIX_ID = 'kb_ask_feedback_needs_fix';
+
+function buildAskAnswerContent(answer, sources) {
+    const content = `${String(answer ?? '')}\n\n${ASK_WARNING_PREFIX}`;
+    const publicSources = (sources ?? []).filter((source) => source?.visibility !== 'kb_only');
+
+    if (!publicSources.length) return content;
+    return `${content}\n> -# Tags: ${publicSources
+        .slice(0, 5)
+        .map((source) => `\`${source.tagId}\``)
+        .join(', ')}`;
+}
+
+function extractAskAnswerContent(content) {
+    const text = String(content ?? '').trim();
+    const footerStart = text.lastIndexOf(`\n\n${ASK_WARNING_PREFIX}`);
+    if (footerStart < 0) return text;
+
+    const footer = text.slice(footerStart + 2);
+    if (footer !== ASK_WARNING_PREFIX && !footer.startsWith(`${ASK_WARNING_PREFIX}\n> -# Tags:`)) return text;
+    return text.slice(0, footerStart).trim();
+}
+
+function buildAskFeedbackComponents(selectedId) {
+    return [
+        {
+            type: 1,
+            components: [
+                {
+                    type: 2,
+                    custom_id: ASK_FEEDBACK_HELPFUL_ID,
+                    style: selectedId === ASK_FEEDBACK_HELPFUL_ID ? 3 : 2,
+                    label: selectedId === ASK_FEEDBACK_HELPFUL_ID ? 'Helpful ✓' : 'Helpful',
+                    disabled: Boolean(selectedId),
+                },
+                {
+                    type: 2,
+                    custom_id: ASK_FEEDBACK_NEEDS_FIX_ID,
+                    style: selectedId === ASK_FEEDBACK_NEEDS_FIX_ID ? 4 : 2,
+                    label: selectedId === ASK_FEEDBACK_NEEDS_FIX_ID ? 'Needs Fix ✓' : 'Needs Fix',
+                    disabled: Boolean(selectedId),
+                },
+            ],
+        },
+    ];
+}
+
+function getAskFeedbackRating(customId) {
+    switch (customId) {
+        case ASK_FEEDBACK_HELPFUL_ID:
+            return { id: ASK_FEEDBACK_HELPFUL_ID, label: 'Helpful', color: 10412190 };
+        case ASK_FEEDBACK_NEEDS_FIX_ID:
+            return { id: ASK_FEEDBACK_NEEDS_FIX_ID, label: 'Needs Fix', color: 16737891 };
+    }
+}
+
+function disableAskFeedbackComponents(components) {
+    return components.map((row) => ({
+        ...row,
+        components: row.components.map((component) => ({ ...component, disabled: true })),
+    }));
+}
 
 function isSnailAskThreadChannel(channel, botUserId) {
     return isThreadChannel(channel) && Boolean(botUserId && channel?.ownerID === botUserId);
@@ -30,7 +93,7 @@ function buildAskConversationHistory(messages, botUserId, prefixes = []) {
 
             turns.push({
                 user: pendingUser?.content,
-                assistant: cleanAskAnswerContent(message.content),
+                assistant: extractAskAnswerContent(message.content),
             });
             continue;
         }
@@ -125,7 +188,13 @@ function isAskCommandMessage(content, prefixes = []) {
 
 function isSnailAskAnswerMessage(message, botUserId) {
     if (!isBotMessage(message, botUserId)) return false;
-    return String(message.content ?? '').startsWith(ASK_WARNING_PREFIX);
+    const buttonIds = new Set(
+        (message.components ?? [])
+            .flatMap((row) => row.components ?? [])
+            .filter((component) => component?.type === 2)
+            .map((component) => component.custom_id)
+    );
+    return buttonIds.has(ASK_FEEDBACK_HELPFUL_ID) && buttonIds.has(ASK_FEEDBACK_NEEDS_FIX_ID);
 }
 
 function isThreadChannel(channel) {
@@ -179,13 +248,6 @@ function cleanUserMessageContent(content, botUserId, prefixes) {
     return text;
 }
 
-function cleanAskAnswerContent(content) {
-    return String(content ?? '')
-        .replace(new RegExp(`^${escapeRegExp(ASK_WARNING_PREFIX)}\\s*`, 'i'), '')
-        .replace(/\n\n> -# Tags:.*$/s, '')
-        .trim();
-}
-
 function truncateForHistory(content, maxChars) {
     const text = String(content ?? '').trim();
     if (text.length <= maxChars) return text;
@@ -204,15 +266,14 @@ function compareDiscordMessageIds(a, b) {
     }
 }
 
-function escapeRegExp(value) {
-    return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 module.exports = {
     ASK_HISTORY_FETCH_LIMIT,
-    ASK_WARNING_PREFIX,
+    buildAskAnswerContent,
     buildAskConversationHistory,
+    buildAskFeedbackComponents,
+    disableAskFeedbackComponents,
     formatRetrievalQuery,
+    getAskFeedbackRating,
     isAskCommandMessage,
     isSnailAskAnswerMessage,
     isSnailAskThreadChannel,


### PR DESCRIPTION
## Summary
- consolidate Snail ask-answer formatting, extraction, feedback components, and message identity under `AskConversation`
- render the warning footer immediately above public tags and identify ask answers by Snail authorship plus both feedback buttons
- always render/collect feedback buttons, skipping only forwarding when no feedback destination is configured
- load persisted feedback destination before enabling Knowledge Base message handling

## Verification
- external ask-answer protocol harness: 7/7 passed
- deferred startup/configuration harness: 2/2 passed
- `node -c src/modules/KnowledgeBase.js src/modules/knowledge-base/AskConversation.js`
- `npx eslint src/modules/KnowledgeBase.js src/modules/knowledge-base/AskConversation.js`
- `npx prettier --check src/modules/KnowledgeBase.js src/modules/knowledge-base/AskConversation.js`
- `git diff --check origin/master...HEAD`

## Review
- phase specification review: approved
- phase architecture review: approved after startup-order fix
- final broad review: approved
- final ponytail review: approved — lean already
