### PR TITLE
fix(kb): require explicit mention content

### DIFF
--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -12,6 +12,7 @@ const {
     disableAskFeedbackComponents,
     formatRetrievalQuery,
     getAskFeedbackRating,
+    hasExplicitBotMention,
     isAskCommandMessage,
     isSnailAskAnswerMessage,
     isSnailAskThreadChannel,
@@ -153,17 +154,17 @@ module.exports = class KnowledgeBase extends require('./Module') {
 
     async onMessage(message) {
         if (message.author?.bot) return;
-        const mentioned = message.mentions?.some((u) => u.id === this.bot.user?.id);
+        const explicitMention = hasExplicitBotMention(message.content, this.bot.user?.id);
         if (
             message.type === Eris.Constants.MessageTypes.REPLY &&
-            !mentioned &&
+            !explicitMention &&
             !isSnailAskThreadChannel(message.channel, this.bot.user?.id)
         )
             return;
-        if (!mentioned && isAskCommandMessage(message.content, this.askCommandPrefixes)) return;
+        if (!explicitMention && isAskCommandMessage(message.content, this.askCommandPrefixes)) return;
 
-        const askThreadReply = mentioned ? false : await this.isAskThreadReplyMessage(message);
-        if (!mentioned && !askThreadReply) return;
+        const askThreadReply = explicitMention ? false : await this.isAskThreadReplyMessage(message);
+        if (!explicitMention && !askThreadReply) return;
 
         const channelIds = [...new Set([message.channel.id, message.channel.parentID].filter(Boolean))];
         const channels = await Promise.all(

--- a/src/modules/knowledge-base/AskConversation.js
+++ b/src/modules/knowledge-base/AskConversation.js
@@ -162,7 +162,7 @@ function formatHistoryForPrompt(history, maxChars) {
 function isAskFlowUserMessage(message, botUserId, askAnswerMessageIds, prefixes) {
     if (message.author?.bot) return false;
     if (isAskCommandMessage(message.content, prefixes)) return true;
-    if (mentionsBot(message, botUserId)) return true;
+    if (hasExplicitBotMention(message.content, botUserId)) return true;
     return isReplyToSnailAskAnswerMessage(message, botUserId, askAnswerMessageIds);
 }
 
@@ -216,10 +216,9 @@ function getReferencedMessageId(message) {
     return message?.messageReference?.messageID || message?.messageReference?.message_id;
 }
 
-function mentionsBot(message, botUserId) {
+function hasExplicitBotMention(content, botUserId) {
     if (!botUserId) return false;
-    if (message.mentions?.some((user) => user.id === botUserId)) return true;
-    return new RegExp(`<@!?${botUserId}>`).test(String(message.content ?? ''));
+    return new RegExp(`<@!?${botUserId}>`).test(String(content ?? ''));
 }
 
 function isBotMessage(message, botUserId) {
@@ -274,6 +273,7 @@ module.exports = {
     disableAskFeedbackComponents,
     formatRetrievalQuery,
     getAskFeedbackRating,
+    hasExplicitBotMention,
     isAskCommandMessage,
     isSnailAskAnswerMessage,
     isSnailAskThreadChannel,


### PR DESCRIPTION
## Summary

- determine explicit Snail mentions from mention tokens in message content
- stop Discord reply-generated `message.mentions` entries from bypassing the outside-thread reply gate
- reuse the same content-based mention policy for KB conversation history

## Root cause

Discord populates `message.mentions` with the replied-to user. The automatic Knowledge Base listener treated that array membership as a direct ping, so replying to Snail could bypass the reply gate even when the user did not type a Snail mention.

## Behavior

- `<@SnailId>` and `<@!SnailId>` in content remain explicit mention activation
- reply-generated mention-array membership without a content token is not explicit activation
- valid direct replies to Snail ask answers inside Snail-owned threads continue through reply provenance
- explicit `snail ask` remains CommandHandler-owned

## Verification

- external real-module routing/history harness
- ESLint on both touched files
- Prettier check on both touched files
- Node syntax checks
- `git diff --check`
- separate correctness/architecture review
- ponytail review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of direct bot mentions in messages.
  * Fixed reply and ask-thread filtering to recognize explicit mentions more reliably.
  * Prevented commands and follow-ups from being incorrectly processed when no direct mention is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->