### PR TITLE
fix(kb): extend question editor timeout

### DIFF
--- a/src/commands/modules/kb.js
+++ b/src/commands/modules/kb.js
@@ -516,7 +516,7 @@ async function showQuestions(KB) {
     if (!collectorModule?.create) return;
 
     const filter = (user) => this.message.author.id === user.id;
-    const collector = collectorModule.create(message, filter, { idle: 120000 });
+    const collector = collectorModule.create(message, filter, { idle: 30 * 60 * 1000 });
     collector.on('collect', async (data, interaction) => {
         let acknowledged = false;
         try {


### PR DESCRIPTION
## Summary
- increase the `snail kb questions` editor idle timeout from 2 minutes to 30 minutes
- keep the change scoped to the KB question editor instead of changing all interaction collectors

## Verification
- focused timeout assertion: 1,800,000 ms (30 minutes)
- `node --check src/commands/modules/kb.js`
- `NODE_PATH=/home/chris/projects/snail-bot/node_modules /home/chris/projects/snail-bot/node_modules/.bin/eslint src/commands/modules/kb.js`
- `npx prettier --check src/commands/modules/kb.js`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the question editor’s idle timeout from 2 minutes to 30 minutes, giving you more time to complete edits before the interaction expires.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->