### PR TITLE
feat(apm): trace commands and interactions

### DIFF
--- a/src/commands/modules/kb.js
+++ b/src/commands/modules/kb.js
@@ -516,7 +516,10 @@ async function showQuestions(KB) {
     if (!collectorModule?.create) return;
 
     const filter = (user) => this.message.author.id === user.id;
-    const collector = collectorModule.create(message, filter, { idle: 30 * 60 * 1000 });
+    const collector = collectorModule.create(message, filter, {
+        idle: 30 * 60 * 1000,
+        getTransactionId: getQuestionEditorTransactionId,
+    });
     collector.on('collect', async (data, interaction) => {
         let acknowledged = false;
         try {
@@ -532,7 +535,7 @@ async function showQuestions(KB) {
                         await answerMessage.delete().catch(() => {});
                         answerMessage = null;
                     }
-                    collector.stop('missing');
+                    await collector.stop('missing');
                     return;
                 }
                 editor = result.editor;
@@ -568,7 +571,7 @@ async function showQuestions(KB) {
                             await answerMessage.delete().catch(() => {});
                             answerMessage = null;
                         }
-                        collector.stop('missing');
+                        await collector.stop('missing');
                         return;
                     }
 
@@ -608,6 +611,19 @@ async function showQuestions(KB) {
         disableComponents(content);
         await message.edit(content).catch(() => {});
     });
+}
+
+function getQuestionEditorTransactionId(data) {
+    if (
+        data.isModal &&
+        data.components?.some((row) =>
+            row.components?.some((component) => component.custom_id === QUESTION_MODAL_INPUT_ID)
+        )
+    ) {
+        return 'kb:questions:save';
+    }
+    if (data.custom_id === QUESTIONS_EDIT_ID) return 'kb:questions:edit';
+    if (data.custom_id === QUESTIONS_GENERATE_ID) return 'kb:questions:regenerate';
 }
 
 function renderQuestionEditorMessages(command, editor, notice = '') {

--- a/src/commands/modules/kb.js
+++ b/src/commands/modules/kb.js
@@ -516,7 +516,7 @@ async function showQuestions(KB) {
     if (!collectorModule?.create) return;
 
     const filter = (user) => this.message.author.id === user.id;
-    const collector = collectorModule.create(message, filter, { idle: 120000 });
+    const collector = collectorModule.create(message, filter, { idle: 30 * 60 * 1000 });
     collector.on('collect', async (data, interaction) => {
         let acknowledged = false;
         try {

--- a/src/modules/CommandHandler.js
+++ b/src/modules/CommandHandler.js
@@ -67,78 +67,91 @@ module.exports = class CommandHandler extends require('./Module') {
         const command = this.commands[message.command];
         if (!command) return;
 
-        // Check if that command has been disabled in this channel or its parent
-        const channelIds = [...new Set([message.channel.id, message.channel.parentID].filter(Boolean))];
-        const channels = await Promise.all(
-            channelIds.map((channelId) => this.bot.snail_db.Channel.findById(channelId))
-        );
-        if (channels.some((channel) => channel?.disabledCommands.includes(command.alias[0]))) {
-            if (this.disabledCooldowns[message.author.id + message.command]) return;
+        const elasticApm = this.bot.modules.elasticapm;
+        const transaction = elasticApm?.startTransaction(`command:${message.command}`, 'bot');
+        let outcome = 'success';
 
-            this.disabledCooldowns[message.author.id + message.command] = true;
-            setTimeout(() => {
-                delete this.disabledCooldowns[message.author.id + message.command];
-            }, DISABLED_WARNING_TIMEOUT);
-            await ephemeralResponse(
-                message,
-                `🚫 **| ${getUniqueUsername(message.author)}**, that command has been disabled in this channel!`,
-                DISABLED_WARNING_TIMEOUT
+        try {
+            // Check if that command has been disabled in this channel or its parent
+            const channelIds = [...new Set([message.channel.id, message.channel.parentID].filter(Boolean))];
+            const channels = await Promise.all(
+                channelIds.map((channelId) => this.bot.snail_db.Channel.findById(channelId))
             );
-            return;
-        }
+            if (channels.some((channel) => channel?.disabledCommands.includes(command.alias[0]))) {
+                if (this.disabledCooldowns[message.author.id + message.command]) return;
 
-        const context = {
-            message,
-            command,
-            config: this.bot.config,
-            snail_db: this.bot.snail_db,
-            bot: this.bot,
-            commands: this.commands,
-            send: async (msg) => {
-                return message.channel.createMessage(msg);
-            },
-            error: async (errorMessage) => {
-                return await ephemeralResponse(
+                this.disabledCooldowns[message.author.id + message.command] = true;
+                setTimeout(() => {
+                    delete this.disabledCooldowns[message.author.id + message.command];
+                }, DISABLED_WARNING_TIMEOUT);
+                await ephemeralResponse(
                     message,
-                    `🚫 **| ${getUniqueUsername(message.author)}**, ${errorMessage}`
+                    `🚫 **| ${getUniqueUsername(message.author)}**, that command has been disabled in this channel!`,
+                    DISABLED_WARNING_TIMEOUT
                 );
-            },
-        };
-
-        if (command.sendTyping) await message.channel.sendTyping();
-
-        if (command.auth(message.member)) {
-            // Staff are not bound by the chains of cooldowns >:)
-            if (!isStaff(message.member)) {
-                const commandName = command.alias[0];
-                const key = `${message.author.id}_${commandName}`;
-
-                const cooldown = this.cooldowns[key] ?? { lastused: new Date(0), warned: false };
-                const now = Date.now();
-
-                // Difference in milliseconds
-                const diff = now - cooldown.lastused;
-
-                // If still on cooldown
-                if (diff < (command.cooldown ?? 0)) {
-                    // If not already warned, warn, otherwise ignore
-                    if (cooldown.warned) return;
-
-                    this.cooldowns[key].warned = true;
-                    await context.error(
-                        `slow down and try the command again **<t:${((command.cooldown - diff + now) / 1000).toFixed(
-                            0
-                        )}:R>**`
-                    );
-                    return;
-                } else {
-                    this.cooldowns[key] = { lastused: now, warned: false };
-                }
+                return;
             }
 
-            await command.execute.bind(context)();
-        } else {
-            await context.error('you do not have permission to use this command!');
+            const context = {
+                message,
+                command,
+                config: this.bot.config,
+                snail_db: this.bot.snail_db,
+                bot: this.bot,
+                commands: this.commands,
+                send: async (msg) => {
+                    return message.channel.createMessage(msg);
+                },
+                error: async (errorMessage) => {
+                    return await ephemeralResponse(
+                        message,
+                        `🚫 **| ${getUniqueUsername(message.author)}**, ${errorMessage}`
+                    );
+                },
+            };
+
+            if (command.sendTyping) await message.channel.sendTyping();
+
+            if (command.auth(message.member)) {
+                // Staff are not bound by the chains of cooldowns >:)
+                if (!isStaff(message.member)) {
+                    const commandName = command.alias[0];
+                    const key = `${message.author.id}_${commandName}`;
+
+                    const cooldown = this.cooldowns[key] ?? { lastused: new Date(0), warned: false };
+                    const now = Date.now();
+
+                    // Difference in milliseconds
+                    const diff = now - cooldown.lastused;
+
+                    // If still on cooldown
+                    if (diff < (command.cooldown ?? 0)) {
+                        // If not already warned, warn, otherwise ignore
+                        if (cooldown.warned) return;
+
+                        this.cooldowns[key].warned = true;
+                        await context.error(
+                            `slow down and try the command again **<t:${(
+                                (command.cooldown - diff + now) /
+                                1000
+                            ).toFixed(0)}:R>**`
+                        );
+                        return;
+                    } else {
+                        this.cooldowns[key] = { lastused: now, warned: false };
+                    }
+                }
+
+                await command.execute.bind(context)();
+            } else {
+                await context.error('you do not have permission to use this command!');
+            }
+        } catch (err) {
+            outcome = 'failure';
+            throw err;
+        } finally {
+            transaction?.setOutcome(outcome);
+            transaction?.end();
         }
     }
 };

--- a/src/modules/InteractionCollector.js
+++ b/src/modules/InteractionCollector.js
@@ -23,7 +23,23 @@ module.exports = class InteractionCollector extends require('./Module') {
             listener = this.listeners[interaction.data.custom_id];
             interaction.data.isModal = true;
         }
-        listener?.interact(interaction, user);
+        if (!listener) return;
+
+        const transactionId = listener.getTransactionId(interaction.data);
+        if (!transactionId) return await listener.interact(interaction, user);
+
+        const elasticApm = this.bot.modules.elasticapm;
+        const transaction = elasticApm?.startTransaction(`interaction:${transactionId}`, 'bot');
+        let outcome = 'success';
+        try {
+            return await listener.interact(interaction, user);
+        } catch (err) {
+            outcome = 'failure';
+            throw err;
+        } finally {
+            transaction?.setOutcome(outcome);
+            transaction?.end();
+        }
     }
 
     create(msg, filter, opt = {}) {
@@ -37,14 +53,15 @@ module.exports = class InteractionCollector extends require('./Module') {
 };
 
 class InteractionEventEmitter extends EventEmitter {
-    constructor(filter, { time = null, idle = null }) {
+    constructor(filter, { time = null, idle = null, getTransactionId = () => undefined }) {
         super();
         this.filter = filter;
         this.ended = false;
         this.idleTimeout = idle;
+        this.getTransactionId = getTransactionId;
 
-        if (time) this.time = setTimeout(() => this.stop('time'), time);
-        if (idle) this.idle = setTimeout(() => this.stop('idle'), idle);
+        if (time) this.time = setTimeout(() => this.stop('time').catch(console.error), time);
+        if (idle) this.idle = setTimeout(() => this.stop('idle').catch(console.error), idle);
     }
 
     checkFilter(user) {
@@ -64,16 +81,37 @@ class InteractionEventEmitter extends EventEmitter {
             return await interaction.createMessage(ephemeralMsg);
         }
 
-        this.emit('collect', interaction.data, interaction, user);
+        const completion = this.emitAndWait('collect', interaction.data, interaction, user);
 
         if (this.idleTimeout) {
             clearTimeout(this.idle);
-            this.idle = setTimeout(() => this.stop('idle'), this.idleTimeout);
+            this.idle = setTimeout(() => this.stop('idle').catch(console.error), this.idleTimeout);
         }
+
+        await completion;
+    }
+
+    // Mirror eventemitter3's dispatch semantics while retaining listener promises.
+    emitAndWait(event, ...args) {
+        const eventName = EventEmitter.prefixed ? `${EventEmitter.prefixed}${event}` : event;
+        const handlers = this._events[eventName];
+        if (!handlers) return Promise.resolve([]);
+
+        const listeners = handlers.fn ? [handlers] : handlers.slice();
+        const completions = [];
+        for (const listener of listeners) {
+            if (listener.once) this.removeListener(event, listener.fn, undefined, true);
+            completions.push(listener.fn.call(listener.context, ...args));
+        }
+        return Promise.allSettled(completions).then((results) => {
+            const failure = results.find((result) => result.status === 'rejected');
+            if (failure) throw failure.reason;
+            return results.map((result) => result.value);
+        });
     }
 
     stop(reason) {
-        if (this.ended) return;
+        if (this.ended) return this.endPromise;
         this.ended = true;
 
         if (this.time) {
@@ -86,7 +124,9 @@ class InteractionEventEmitter extends EventEmitter {
             this.idle = null;
         }
 
-        this.emit('end', reason);
+        const endPromise = this.emitAndWait('end', reason);
         this.removeAllListeners();
+        this.endPromise = endPromise;
+        return this.endPromise;
     }
 }

--- a/src/modules/KnowledgeBase.js
+++ b/src/modules/KnowledgeBase.js
@@ -281,7 +281,10 @@ module.exports = class KnowledgeBase extends require('./Module') {
     collectAskFeedback(collectorModule, answerMessage, content, feedback) {
         let submitted = false;
         const filter = (user) => user?.id === feedback.originalMessage.author?.id;
-        const collector = collectorModule.create(answerMessage, filter, { idle: ASK_FEEDBACK_IDLE_MS });
+        const collector = collectorModule.create(answerMessage, filter, {
+            idle: ASK_FEEDBACK_IDLE_MS,
+            getTransactionId: (data) => getAskFeedbackTransactionId(data.custom_id),
+        });
 
         collector.on('collect', async (data, interaction) => {
             const rating = getAskFeedbackRating(data.custom_id);
@@ -295,7 +298,7 @@ module.exports = class KnowledgeBase extends require('./Module') {
                 content.components = buildAskFeedbackComponents(rating.id);
                 await answerMessage.edit(content).catch(() => {});
                 await interaction.createMessage(ephemeralInteractionResponse(`✅ **|** Thank you for your feedback!`));
-                collector.stop('submitted');
+                await collector.stop('submitted');
             } catch (err) {
                 console.error('[KB] ask feedback forward failed:', err.message);
                 await interaction
@@ -352,19 +355,21 @@ module.exports = class KnowledgeBase extends require('./Module') {
     }
 
     async ask(question, { message } = {}) {
-        const transaction = this.elasticApm.startTransaction('snail.ask.fetch', 'bot');
+        const trace = this.elasticApm.currentTransaction
+            ? this.elasticApm.startSpan('snail.ask.fetch', 'bot')
+            : this.elasticApm.startTransaction('snail.ask.fetch', 'bot');
 
         try {
-            transaction?.setLabel('question_length', question.length);
+            trace?.setLabel('question_length', question.length);
             const result = await this.fetchAskAnswer(question, { message });
-            transaction?.setOutcome('success');
+            trace?.setOutcome('success');
             return result;
         } catch (err) {
-            transaction?.setOutcome('failure');
+            trace?.setOutcome('failure');
             this.elasticApm.captureError(err);
             throw err;
         } finally {
-            transaction?.end();
+            trace?.end();
         }
     }
 
@@ -1015,6 +1020,12 @@ module.exports = class KnowledgeBase extends require('./Module') {
         );
     }
 };
+
+function getAskFeedbackTransactionId(customId) {
+    const rating = getAskFeedbackRating(customId);
+    if (rating?.id === 'kb_ask_feedback_helpful') return 'kb:feedback:helpful';
+    if (rating?.id === 'kb_ask_feedback_needs_fix') return 'kb:feedback:needs-fix';
+}
 
 // ─── Pure helpers ───────────────────────────────────────────────────────
 

--- a/src/modules/QuestList.js
+++ b/src/modules/QuestList.js
@@ -31,6 +31,11 @@ const COMPONENTS = [
         ],
     },
 ];
+const INTERACTION_TRANSACTION_IDS = {
+    questlist_queue_position: 'questlist:queue-position',
+    questlist_reload_mentions: 'questlist:reload-mentions',
+    questlist_toggle_reminders: 'questlist:toggle-reminders',
+};
 
 module.exports = class QuestList extends require('./Module') {
     constructor(bot) {
@@ -284,72 +289,91 @@ module.exports = class QuestList extends require('./Module') {
         // If not a component interaction, ignore
         if (type != 3) return;
 
-        switch (custom_id) {
-            case 'questlist_queue_position': {
-                const USERS_ON_LIST = Object.fromEntries(Object.keys(QUEST_DATA).map((type) => [type, new Array()]));
+        const transactionId = INTERACTION_TRANSACTION_IDS[custom_id];
+        if (!transactionId) return;
 
-                for (const { type, discordID } of this.quests) {
-                    if (!USERS_ON_LIST[type].includes(discordID)) USERS_ON_LIST[type].push(discordID);
+        const elasticApm = this.bot.modules.elasticapm;
+        const transaction = elasticApm?.startTransaction(`interaction:${transactionId}`, 'bot');
+        let outcome = 'success';
+
+        try {
+            switch (custom_id) {
+                case 'questlist_queue_position': {
+                    const USERS_ON_LIST = Object.fromEntries(
+                        Object.keys(QUEST_DATA).map((type) => [type, new Array()])
+                    );
+
+                    for (const { type, discordID } of this.quests) {
+                        if (!USERS_ON_LIST[type].includes(discordID)) USERS_ON_LIST[type].push(discordID);
+                    }
+
+                    const POSITIONS = {};
+
+                    for (const type in USERS_ON_LIST) {
+                        POSITIONS[type] = USERS_ON_LIST[type].findIndex((userID) => userID == MEMBER_ID);
+                    }
+
+                    let content = Object.entries(POSITIONS)
+                        .map(([type, position]) => {
+                            let base = `__**${QUEST_DATA[type].name}:**__`;
+
+                            if (position == -1) return `${base} You are not on this list`;
+
+                            const MAX = this.capacity[type] ?? Infinity;
+
+                            if (position < MAX) return `${base} Your quest is currently being shown`;
+
+                            return `${base} Your quest is in the queue at position ${position - MAX + 1}`;
+                        })
+                        .join('\n');
+
+                    await interaction.createMessage({ content, flags: 1 << 6 });
+                    break;
                 }
+                case 'questlist_reload_mentions': {
+                    const USERS_ON_LIST = Object.fromEntries(
+                        Object.keys(QUEST_DATA).map((type) => [type, new Array()])
+                    );
 
-                const POSITIONS = {};
+                    for (const { type, discordID } of this.quests) {
+                        if (!USERS_ON_LIST[type].includes(discordID)) USERS_ON_LIST[type].push(discordID);
+                    }
 
-                for (const type in USERS_ON_LIST) {
-                    POSITIONS[type] = USERS_ON_LIST[type].findIndex((userID) => userID == MEMBER_ID);
+                    let content = Object.entries(USERS_ON_LIST)
+                        .map(([type, userIDs]) => {
+                            let base = `__**${QUEST_DATA[type].name}:**__`;
+
+                            const MAX = this.capacity[type] ?? userIDs.length;
+                            const USERS_ON_DISPLAY = userIDs.splice(0, MAX);
+
+                            return `${base} ${USERS_ON_DISPLAY.map((userID) => `<@${userID}>`).join(' ')}`;
+                        })
+                        .join('\n');
+
+                    await interaction.createMessage({ content, flags: 1 << 6 });
+                    break;
                 }
+                case 'questlist_toggle_reminders': {
+                    let enabled = (await this.bot.snail_db.User.findById(MEMBER_ID))?.reminders?.luck?.enabled;
+                    await this.bot.snail_db.User.updateOne(
+                        { _id: MEMBER_ID },
+                        { reminders: { luck: { enabled: !(enabled ?? false) } } },
+                        { upsert: true }
+                    );
 
-                let content = Object.entries(POSITIONS)
-                    .map(([type, position]) => {
-                        let base = `__**${QUEST_DATA[type].name}:**__`;
-
-                        if (position == -1) return `${base} You are not on this list`;
-
-                        const MAX = this.capacity[type] ?? Infinity;
-
-                        if (position < MAX) return `${base} Your quest is currently being shown`;
-
-                        return `${base} Your quest is in the queue at position ${position - MAX + 1}`;
-                    })
-                    .join('\n');
-
-                await interaction.createMessage({ content, flags: 1 << 6 });
-                break;
-            }
-            case 'questlist_reload_mentions': {
-                const USERS_ON_LIST = Object.fromEntries(Object.keys(QUEST_DATA).map((type) => [type, new Array()]));
-
-                for (const { type, discordID } of this.quests) {
-                    if (!USERS_ON_LIST[type].includes(discordID)) USERS_ON_LIST[type].push(discordID);
+                    await interaction.createMessage({
+                        content: `You have ${enabled ? 'disabled' : 'enabled'} pray/curse reminders.`,
+                        flags: 1 << 6,
+                    });
+                    break;
                 }
-
-                let content = Object.entries(USERS_ON_LIST)
-                    .map(([type, userIDs]) => {
-                        let base = `__**${QUEST_DATA[type].name}:**__`;
-
-                        const MAX = this.capacity[type] ?? userIDs.length;
-                        const USERS_ON_DISPLAY = userIDs.splice(0, MAX);
-
-                        return `${base} ${USERS_ON_DISPLAY.map((userID) => `<@${userID}>`).join(' ')}`;
-                    })
-                    .join('\n');
-
-                await interaction.createMessage({ content, flags: 1 << 6 });
-                break;
             }
-            case 'questlist_toggle_reminders': {
-                let enabled = (await this.bot.snail_db.User.findById(MEMBER_ID))?.reminders?.luck?.enabled;
-                await this.bot.snail_db.User.updateOne(
-                    { _id: MEMBER_ID },
-                    { reminders: { luck: { enabled: !(enabled ?? false) } } },
-                    { upsert: true }
-                );
-
-                await interaction.createMessage({
-                    content: `You have ${enabled ? 'disabled' : 'enabled'} pray/curse reminders.`,
-                    flags: 1 << 6,
-                });
-                break;
-            }
+        } catch (err) {
+            outcome = 'failure';
+            throw err;
+        } finally {
+            transaction?.setOutcome(outcome);
+            transaction?.end();
         }
     }
 

--- a/src/modules/UserInteractionHandler.js
+++ b/src/modules/UserInteractionHandler.js
@@ -37,34 +37,46 @@ module.exports = class UserInteractionHandler extends require('./Module') {
             return;
         }
 
-        const context = {
-            interaction,
-            target: this.getTargetUser(interaction),
-            config: this.bot.config,
-            snail_db: this.bot.snail_db,
-            bot: this.bot,
-            send: async (msg) => {
-                return await interaction.createMessage(msg);
-            },
-            sendEphemeral: async (msg) => {
-                const ephemeralMsg = ephemeralInteractionResponse(msg);
-                return await interaction.createMessage(ephemeralMsg);
-            },
-            error: async (errorMsg) => {
-                errorMsg = `🚫 **| ${getUniqueUsername(interaction.user)}**, ${errorMsg}`;
-                const ephemeralMessage = ephemeralInteractionResponse(errorMsg);
-                return await interaction.createMessage(ephemeralMessage);
-            },
-            createInteractionCollector: (msg, filter, opt) => {
-                return this.bot.modules['interactioncollector'].create(msg, filter, opt);
-            },
-        };
+        const elasticApm = this.bot.modules.elasticapm;
+        const transaction = elasticApm?.startTransaction(`interaction:user:${userInteraction.transactionId}`, 'bot');
+        let outcome = 'success';
 
-        if (userInteraction.ownerOnly && !isOwnerUser(interaction.user)) {
-            await context.error('this user command is for owners only!');
-            return;
+        try {
+            const context = {
+                interaction,
+                target: this.getTargetUser(interaction),
+                config: this.bot.config,
+                snail_db: this.bot.snail_db,
+                bot: this.bot,
+                send: async (msg) => {
+                    return await interaction.createMessage(msg);
+                },
+                sendEphemeral: async (msg) => {
+                    const ephemeralMsg = ephemeralInteractionResponse(msg);
+                    return await interaction.createMessage(ephemeralMsg);
+                },
+                error: async (errorMsg) => {
+                    errorMsg = `🚫 **| ${getUniqueUsername(interaction.user)}**, ${errorMsg}`;
+                    const ephemeralMessage = ephemeralInteractionResponse(errorMsg);
+                    return await interaction.createMessage(ephemeralMessage);
+                },
+                createInteractionCollector: (msg, filter, opt) => {
+                    return this.bot.modules['interactioncollector'].create(msg, filter, opt);
+                },
+            };
+
+            if (userInteraction.ownerOnly && !isOwnerUser(interaction.user)) {
+                await context.error('this user command is for owners only!');
+                return;
+            }
+            await userInteraction.execute.bind(context)();
+        } catch (err) {
+            outcome = 'failure';
+            throw err;
+        } finally {
+            transaction?.setOutcome(outcome);
+            transaction?.end();
         }
-        await userInteraction.execute.bind(context)();
     }
 
     getTargetUser({ data }) {

--- a/src/user-interaction/GiveItem.js
+++ b/src/user-interaction/GiveItem.js
@@ -45,6 +45,7 @@ let previousSelection;
 
 module.exports = new UserInteraction({
     name: 'Give Item',
+    transactionId: 'give-item',
 
     ownerOnly: true,
 
@@ -56,7 +57,10 @@ module.exports = new UserInteraction({
         await this.sendEphemeral(content);
 
         const filter = (user) => this.interaction.user.id === user.id;
-        const collector = this.createInteractionCollector(this.interaction, filter, { idle: 120000 });
+        const collector = this.createInteractionCollector(this.interaction, filter, {
+            idle: 120000,
+            getTransactionId: getGiveItemTransactionId,
+        });
 
         let selected = content.components[0].components[0].options.find((option) => option.default)?.value;
         collector.on('collect', async (data, interaction, _user) => {
@@ -78,7 +82,7 @@ module.exports = new UserInteraction({
                     return;
                 case cancelId:
                     await interaction.acknowledge();
-                    collector.stop('stop');
+                    await collector.stop('stop');
                     return;
                 case changeCountId:
                     modal = getCountModal(count, this.interaction.id);
@@ -127,6 +131,28 @@ module.exports = new UserInteraction({
         });
     },
 });
+
+function getGiveItemTransactionId(data) {
+    if (data.isModal) {
+        const customId = data.components?.[0]?.components?.[0]?.custom_id;
+        if (customId === countModalId) return 'give-item:save-count';
+        if (customId === userModalId) return 'give-item:save-user';
+        return;
+    }
+
+    switch (data.custom_id) {
+        case selectId:
+            return 'give-item:select';
+        case sendId:
+            return 'give-item:send';
+        case cancelId:
+            return 'give-item:cancel';
+        case changeCountId:
+            return 'give-item:change-count';
+        case changeUserId:
+            return 'give-item:change-user';
+    }
+}
 
 function getContent(user, count) {
     const options = [];

--- a/src/user-interaction/SendUserData.js
+++ b/src/user-interaction/SendUserData.js
@@ -5,6 +5,7 @@ const query = require('../databases/mysql/mysql.js');
 
 module.exports = new UserInteraction({
     name: 'Send User Data',
+    transactionId: 'send-user-data',
 
     ownerOnly: true,
 

--- a/src/user-interaction/UserInteraction.js
+++ b/src/user-interaction/UserInteraction.js
@@ -1,6 +1,7 @@
 module.exports = class UserInteraction {
     constructor(args) {
         this.name = args.name;
+        this.transactionId = args.transactionId;
         this.ownerOnly = !!args.ownerOnly;
         this.execute = args.execute;
     }


### PR DESCRIPTION
## Summary

- wrap every recognized Snail command alias and top-level user interaction in an Elastic APM transaction that spans gates and complete async execution
- add producer-owned semantic transaction names for Give Item, KB question/feedback collectors, and Quest List actions while keeping unknown and dynamic IDs transaction-free
- make collector callback and end-listener completion awaitable without changing EventEmitter3 dispatch semantics
- use `snail.ask.fetch` as a child span under command transactions while retaining standalone tracing for automatic asks

## Verification

- `node --check` on all 9 changed JavaScript files
- Prettier check on all 9 changed files
- `git diff --check`
- external command transaction harness
- external user-interaction transaction harness
- external collector transaction/end-lifecycle harness
- external EventEmitter3 5.0.1 completion-contract harness
- external Quest List transaction harness
- external Knowledge Base standalone/child trace harness
- external semantic route-ownership harness

Repository-wide ESLint still reports the same 13 pre-existing errors as `origin/master`; focused changed-file ESLint reports the same 10 pre-existing errors in `GiveItem.js` and `SendUserData.js`. Repository-wide Prettier remains blocked by the existing NDJSON-style `tags.json`; all changed files pass.
